### PR TITLE
introduce METAL_AUTH_TOKEN to replace PACKET_AUTH_TOKEN

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -66,12 +66,12 @@ jobs:
         # TF_LOG: "DEBUG"
         #
 
-        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+        METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
         go test -v -cover -parallel 4 -timeout 120m ./metal
     - name: Sweeper
       if: ${{ always() }}
       env:
-        PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
+        METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
         go test ./metal -v -sweep="tf_test"

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,8 @@ resource "metal_device" "web1" {
 The following arguments are supported:
 
 * `auth_token` - (Required) This is your Equinix Metal API Auth token. This can
-  also be specified with the `METAL_AUTH_TOKEN` or `PACKET_AUTH_TOKEN` shell
-  environment variable.
+  also be specified with the `METAL_AUTH_TOKEN` environment variable.
+
+  Use of the legacy `PACKET_AUTH_TOKEN` environment variable is deprecated.
 * `max_retries` - Maximum number of retries in case of network failure.
 * `max_retry_wait_seconds` - Maximum time to wait in case of network failure.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,8 @@ resource "metal_device" "web1" {
 
 The following arguments are supported:
 
-* `auth_token` - (Required) This is your Equinix Metal API Auth token. This can also be specified
-  with the `PACKET_AUTH_TOKEN` shell environment variable.
+* `auth_token` - (Required) This is your Equinix Metal API Auth token. This can
+  also be specified with the `METAL_AUTH_TOKEN` or `PACKET_AUTH_TOKEN` shell
+  environment variable.
 * `max_retries` - Maximum number of retries in case of network failure.
 * `max_retry_wait_seconds` - Maximum time to wait in case of network failure.

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -15,9 +15,12 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"auth_token": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("PACKET_AUTH_TOKEN", nil),
+				Type:     schema.TypeString,
+				Required: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{
+					"METAL_AUTH_TOKEN",
+					"PACKET_AUTH_TOKEN",
+				}, nil),
 				Description: "The API auth key for API operations.",
 			},
 			"max_retries": {

--- a/metal/provider_test.go
+++ b/metal/provider_test.go
@@ -29,7 +29,13 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("PACKET_AUTH_TOKEN"); v == "" {
-		t.Fatal("PACKET_AUTH_TOKEN must be set for acceptance tests")
+	v := os.Getenv("METAL_AUTH_TOKEN")
+
+	if v == "" {
+		v = os.Getenv("PACKET_AUTH_TOKEN")
+	}
+
+	if v == "" {
+		t.Fatal("METAL_AUTH_TOKEN must be set for acceptance tests")
 	}
 }

--- a/metal/sweeper_test.go
+++ b/metal/sweeper_test.go
@@ -13,13 +13,18 @@ func TestMain(m *testing.M) {
 }
 
 func sharedConfigForRegion(region string) (interface{}, error) {
+	token := os.Getenv("METAL_AUTH_TOKEN")
 
-	if os.Getenv("PACKET_AUTH_TOKEN") == "" {
-		return nil, fmt.Errorf("you must set PACKET_AUTH_TOKEN")
+	if token == "" {
+		token = os.Getenv("PACKET_AUTH_TOKEN")
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("you must set METAL_AUTH_TOKEN")
 	}
 
 	config := Config{
-		AuthToken: os.Getenv("PACKET_AUTH_TOKEN"),
+		AuthToken: token,
 	}
 
 	return config.Client(), nil


### PR DESCRIPTION
`METAL_AUTH_TOKEN` will be used if set, otherwise `PACKET_AUTH_TOKEN` will
continue to be used.

`METAL_AUTH_TOKEN` has not been added to the GitHub Action secrets. The action is still pulling from the old variable name, for now. 

Fixes #26 
