### PR TITLE
use Terraform and provider version as packngo UserAgent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - -s -w -X version.ProviderVersion={{.Version}}
   goos:
     - freebsd
     - windows

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// ProviderVersion is set at build-time in the release process
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
Fixes #19 


When tested locally using `TF_LOG=DEBUG TF_ACC=1 go test ./... -v -timeout=20m -run=TestAcc...`:

```
User-Agent: HashiCorp Terraform/0.11+compatible (+https://www.terraform.io) Terraform Plugin SDK/1.0.0 terraform-provider-metal/dev
```