### PR TITLE
Datasource metal_facility

### DIFF
--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -1,0 +1,42 @@
+---
+page_title: "Equinix Metal: metal_facility"
+subcategory: ""
+description: |-
+  Provides an Equinix Metal facility datasource. This can be used to read facilities.
+---
+
+# metal_facility
+
+Provides an Equinix Metal facility datasource.
+
+## Example Usage
+
+```hcl
+# Fetch a facility by code and show its ID
+
+data "metal_facility" "ewr1" {
+    code = "ewr1"
+}
+
+output "id" {
+  value = data.metal_facility.ewr1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `code` - The facility code
+
+Facilities can be looked up by `code`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the facility
+* `name` - The name of the facilityg system running on the device
+* `features` - The features of the facility
+* `address` - The facility address
+  * `id` - ID of the address

--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -38,5 +38,3 @@ The following attributes are exported:
 * `id` - The ID of the facility
 * `name` - The name of the facilityg system running on the device
 * `features` - The features of the facility
-* `address` - The facility address
-  * `id` - ID of the address

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -1,0 +1,76 @@
+package metal
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourceMetalFacility() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMetalFacilityRead,
+		Schema: map[string]*schema.Schema{
+			"code": {
+				Type:        schema.TypeString,
+				Description: "The code of the Facility to match",
+				Required:    true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of this Facility.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"features": {
+				Type:        schema.TypeList,
+				Description: "The features of this Facility.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+			},
+			"address": {
+				Type:        schema.TypeMap,
+				Description: "The address of this Facility.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					}},
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMetalFacilityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	code := d.Get("code").(string)
+
+	if code == "" {
+		return fmt.Errorf("Error Facility code is required")
+	}
+
+	facilities, _, err := client.Facilities.List(nil)
+	if err != nil {
+		return fmt.Errorf("Error listing Facilities: %s", err)
+	}
+
+	for _, f := range facilities {
+		if f.Code == code {
+			d.SetId(f.ID)
+			return setMap(d, map[string]interface{}{
+				"code":     f.Code,
+				"features": f.Features,
+				"address": map[string]interface{}{
+					"id": f.Address.ID,
+				},
+			})
+		}
+	}
+
+	return fmt.Errorf("Facility %s was not found", code)
+}

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -29,19 +29,6 @@ func dataSourceMetalFacility() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"address": {
-				Type:        schema.TypeMap,
-				Description: "The address of this Facility.",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					}},
-				Optional: true,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -64,10 +51,8 @@ func dataSourceMetalFacilityRead(d *schema.ResourceData, meta interface{}) error
 			d.SetId(f.ID)
 			return setMap(d, map[string]interface{}{
 				"code":     f.Code,
+				"name":     f.Name,
 				"features": f.Features,
-				"address": map[string]interface{}{
-					"id": f.Address.ID,
-				},
 			})
 		}
 	}

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -1,0 +1,31 @@
+package metal
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccFacilityDataSource_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMetalFacilityDataSourceConfigBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.metal_facility.test", "code", "ewr1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMetalFacilityDataSourceConfigBasic() string {
+	return `
+data "metal_facility" "test" {
+    code = "ewr1"
+}
+`
+}

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -32,6 +32,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"metal_facility":             dataSourceMetalFacility(),
 			"metal_ip_block_ranges":      dataSourceMetalIPBlockRanges(),
 			"metal_precreated_ip_block":  dataSourceMetalPreCreatedIPBlock(),
 			"metal_operating_system":     dataSourceOperatingSystem(),


### PR DESCRIPTION
I needed a simple resource to test #30 so I added this non-sensitive data resource that can be tested quickly without creating remote resources.

We may wish to add the ability to lookup facility by ID in the future, I found that all of the existing Terraform resources only expose facility code, so this seemed like the best attribute to start with.

An auth token environment variable is still needed to run the test, there are no unauthenticated endpoints in the EM API.

```
TF_LOG=DEBUG TF_ACC=1 go test ./... -v -timeout=20m -run=TestAccFacilityDataSource_Basic
```