### PR TITLE
use local function for HTTP retry policy

### DIFF
--- a/metal/config.go
+++ b/metal/config.go
@@ -57,7 +57,7 @@ func (c *Config) Client() *packngo.Client {
 	retryClient.RetryMax = c.MaxRetries
 	retryClient.RetryWaitMin = time.Second
 	retryClient.RetryWaitMax = c.MaxRetryWait
-	retryClient.CheckRetry = packngo.RetryPolicy
+	retryClient.CheckRetry = MetalRetryPolicy
 	httpClient := retryClient.StandardClient()
 	return packngo.NewClientWithAuth(consumerToken, c.AuthToken, httpClient)
 }


### PR DESCRIPTION
Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>

this PR substitutes packngo.RetryPolicy for local MetalRetryPolicy