### PR TITLE
Adds Spot market request import

### DIFF
--- a/docs/data-sources/spot_market_request.md
+++ b/docs/data-sources/spot_market_request.md
@@ -78,3 +78,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `device_ids` - List of IDs of devices spawned by the referenced Spot Market Request
+* `devices_min` - Miniumum number devices to be created
+* `devices_max` - Maximum number devices to be created
+* `max_bid_price` - Maximum price user is willing to pay per hour per device
+* `facilities` - Facility IDs where devices should be created
+* `metro` - Metro where devices should be created.
+* `project_id` - Project ID
+* `plan` - The device plan slug.
+* `end_at` - Date and time When the spot market request will be ended.

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -214,3 +214,11 @@ The following attributes are exported:
 * `state` - The status of the device
 * `tags` - Tags attached to the device
 * `updated` - The timestamp for the last time the device was updated
+
+## Import
+
+This resource can be imported using an existing device ID:
+
+```sh
+terraform import metal_device {existing_device_id}
+```

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -39,3 +39,11 @@ The following attributes are exported:
 * `website` - Website link
 * `twitter` - Twitter handle
 * `logo` - Logo URL
+
+## Import
+
+This resource can be imported using an existing organization ID:
+
+```sh
+terraform import metal_organization {existing_organization_id}
+```

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -94,3 +94,11 @@ The `bgp_config` block additionally exports:
 
 * `status` - status of BGP configuration in the project
 * `max_prefix` - The maximum number of route filters allowed per server
+
+## Import
+
+This resource can be imported using an existing project ID:
+
+```sh
+terraform import metal_project {existing_project_id}
+```

--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -114,3 +114,11 @@ The following attributes are exported:
 Idempotent reference to a first "/32" address from a reserved block might look like this:
 
 `join("/", [cidrhost(metal_reserved_ip_block.myblock.cidr_notation,0), "32"])`
+
+## Import
+
+This resource can be imported using an existing IP reservation ID:
+
+```sh
+terraform import metal_reserved_ip_block {existing_ip_reservation_id}
+```

--- a/docs/resources/spot_market_request.md
+++ b/docs/resources/spot_market_request.md
@@ -71,3 +71,11 @@ The following attributes are exported:
 
 * `id` - The ID of the Spot Market Request
 * `facilities` - The facilities where the Spot Market Request is applied. This is computed when `metro` is set or no specific location was requested.
+
+## Import
+
+This resource can be imported using an existing spot market request ID:
+
+```sh
+terraform import metal_spot_market_request {existing_spot_market_request_id}
+```

--- a/docs/resources/spot_market_request.md
+++ b/docs/resources/spot_market_request.md
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `wait_for_devices` - (Optional) On resource creation - wait until all desired devices are active, on resource destruction - wait until devices are removed
 * `facilities` - (Optional) Facility IDs where devices should be created
 * `metro` - (Optional) Metro where devices should be created
+* `locked` - (Optional) Blocks deletion of the SpotMarketRequest device until the lock is disabled
 * `instance_parameters` - (Required) Parameters for devices provisioned from this request. You can find the parameter description from the [metal_device doc](device.md).
   * `billing_cycle`
   * `plan`

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -52,3 +52,11 @@ The following attributes are exported:
 * `owner_id` - The UUID of the Equinix Metal API User who owns this key
 * `created` - The timestamp for when the SSH key was created
 * `updated` - The timestamp for the last time the SSH key was updated
+
+## Import
+
+This resource can be imported using an existing SSH Key ID:
+
+```sh
+terraform import metal_ssh_key {existing_sshkey_id}
+```

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -47,3 +47,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `vxlan` - VXLAN segment ID
+
+## Import
+
+This resource can be imported using an existing VLAN ID (UUID):
+
+```sh
+terraform import metal_vlan {existing_vlan_id}
+```

--- a/metal/datasource_metal_spot_market_request.go
+++ b/metal/datasource_metal_spot_market_request.go
@@ -105,10 +105,15 @@ func dataSourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface
 			}
 			return nil
 		},
-		"devices_max":   smr.DevicesMax,
-		"devices_min":   smr.DevicesMin,
-		"facilities":    facCodes,
-		"metro":         smr.Metro,
+		"devices_max": smr.DevicesMax,
+		"devices_min": smr.DevicesMin,
+		"facilities":  facCodes,
+		"metro": func(d *schema.ResourceData, k string) error {
+			if smr.Metro != nil {
+				return d.Set(k, smr.Metro.Code)
+			}
+			return nil
+		},
 		"max_bid_price": smr.MaxBidPrice,
 		"plan":          smr.Plan.Slug,
 		"project_id":    smr.Project.ID,

--- a/metal/datasource_metal_spot_market_request.go
+++ b/metal/datasource_metal_spot_market_request.go
@@ -1,7 +1,7 @@
 package metal
 
 import (
-	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/packethost/packngo"
@@ -13,13 +13,56 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"request_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Description: "The id of the Spot Market Request",
+				Required:    true,
 			},
 			"device_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
+				Description: "List of IDs of devices spawned by the referenced Spot Market Request",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"devices_min": {
+				Type:        schema.TypeInt,
+				Description: "Miniumum number devices to be created",
+				Computed:    true,
+			},
+			"devices_max": {
+				Type:        schema.TypeInt,
+				Description: "Maximum number devices to be created",
+				Computed:    true,
+			},
+			"max_bid_price": {
+				Type:        schema.TypeFloat,
+				Description: "Maximum price user is willing to pay per hour per device",
+				Computed:    true,
+			},
+			"facilities": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Facility IDs where devices should be created",
+				Computed:    true,
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Description: "Metro where devices should be created.",
+				Computed:    true,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Description: "Project ID",
+				Computed:    true,
+			},
+			"plan": {
+				Type:        schema.TypeString,
+				Description: "The device plan slug.",
+				Computed:    true,
+			},
+			"end_at": {
+				Type:        schema.TypeString,
+				Description: "Date and time When the spot market request will be ended.",
+				Computed:    true,
 			},
 		},
 		Timeouts: resourceDefaultTimeouts,
@@ -42,8 +85,33 @@ func dataSourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface
 	deviceIDs := make([]string, len(smr.Devices))
 	for i, d := range smr.Devices {
 		deviceIDs[i] = d.ID
+
 	}
-	d.Set("device_ids", deviceIDs)
-	d.SetId(id + strings.Join(deviceIDs, "-"))
-	return nil
+
+	facs := smr.Facilities
+	facCodes := []string{}
+
+	for _, f := range facs {
+		facCodes = append(facCodes, f.Code)
+	}
+
+	d.SetId(id)
+
+	return setMap(d, map[string]interface{}{
+		"device_ids": deviceIDs,
+		"end_at": func(d *schema.ResourceData, k string) error {
+			if smr.EndAt != nil {
+				return d.Set(k, smr.EndAt.Format(time.RFC3339))
+			}
+			return nil
+		},
+		"devices_max":   smr.DevicesMax,
+		"devices_min":   smr.DevicesMin,
+		"facilities":    facCodes,
+		"metro":         smr.Metro,
+		"max_bid_price": smr.MaxBidPrice,
+		"plan":          smr.Plan.Slug,
+		"project_id":    smr.Project.ID,
+		// TODO: created_at is not in packngo
+	})
 }

--- a/metal/datasource_metal_spot_market_request_test.go
+++ b/metal/datasource_metal_spot_market_request_test.go
@@ -66,8 +66,8 @@ resource "metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_16_04"
-    plan             = "t1.small.x86"
+    operating_system = "ubuntu_20_04"
+    plan             = "c3.small.x86"
   }
 }
 
@@ -95,8 +95,8 @@ resource "metal_spot_market_request" "req" {
   instance_parameters {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_16_04"
-    plan             = "t1.small.x86"
+    operating_system = "ubuntu_20_04"
+    plan             = "c3.small.x86"
   }
 }
 

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -15,7 +15,9 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 		Create: resourceMetalSpotMarketRequestCreate,
 		Read:   resourceMetalSpotMarketRequestRead,
 		Delete: resourceMetalSpotMarketRequestDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"devices_min": {
 				Type:     schema.TypeInt,

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -3,6 +3,7 @@ package metal
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -33,6 +34,25 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 				Type:     schema.TypeFloat,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldF, err := strconv.ParseFloat(old, 64)
+					if err != nil {
+						return false
+					}
+					newF, err := strconv.ParseFloat(new, 64)
+					if err != nil {
+						return false
+					}
+					// suppress diff if the difference between existing and new bid price
+					// is less than 2%
+					diffThreshold := .02
+					priceDiff := oldF / newF
+
+					if diffThreshold < priceDiff {
+						return true
+					}
+					return false
+				},
 			},
 			"facilities": {
 				Type:          schema.TypeList,

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -111,7 +111,7 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"locked": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
 						},
 						"project_ssh_keys": {
@@ -336,8 +336,7 @@ func resourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface{}
 	d.Set("devices_min", smr.DevicesMin)
 	d.Set("devices_max", smr.DevicesMax)
 	d.Set("max_bid_price", smr.MaxBidPrice)
-	d.Set("instance_parameters", getInstanceParams(smr.Devices))
-	return nil
+	return d.Set("instance_parameters", getInstanceParams(&smr.Parameters))
 }
 
 func resourceMetalSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {
@@ -381,29 +380,27 @@ func resourceMetalSpotMarketRequestDelete(d *schema.ResourceData, meta interface
 
 type InstanceParams []map[string]interface{}
 
-func getInstanceParams(ds []packngo.Device) InstanceParams {
-	ret := InstanceParams{}
-	if len(ds) == 0 {
-		return ret
+func getInstanceParams(params *packngo.SpotMarketRequestInstanceParameters) InstanceParams {
+	p := InstanceParams{{
+		"billing_cycle":    params.BillingCycle,
+		"plan":             params.Plan,
+		"operating_system": params.OperatingSystem,
+		"hostname":         params.Hostname,
+		"always_pxe":       params.AlwaysPXE,
+		"description":      params.Description,
+		"features":         params.Features,
+		"locked":           params.Locked,
+		"project_ssh_keys": params.BillingCycle,
+		"user_ssh_keys":    params.BillingCycle,
+		"userdata":         params.UserData,
+		"customdata":       params.CustomData,
+		"ipxe_script_url":  params.BillingCycle,
+		"tags":             params.Tags,
+	}}
+	if params.TerminationTime != nil {
+		p[0]["termintation_time"] = params.TerminationTime.Time
 	}
-	ips := map[string]interface{}{}
-	ips["billing_cycle"] = ds[0].BillingCycle
-	ips["plan"] = ds[0].Plan.Slug
-	ips["operating_system"] = ds[0].OS.Slug
-	ips["hostname"] = ds[0].Hostname
-	//ips["termintation_time"] = ds[0].TerminationTime.Time //
-	ips["always_pxe"] = ds[0].AlwaysPXE
-	ips["description"] = ds[0].Description
-	//ips["features"] = ds[0].Features
-	ips["locked"] = ds[0].Locked
-	//ips["project_ssh_keys"] = ds[0].BillingCycle
-	//ips["user_ssh_keys"] = ds[0].BillingCycle
-	ips["userdata"] = ds[0].UserData
-	//ips["customdata"] = ds[0].CustomData
-	ips["ipxe_script_url"] = ds[0].BillingCycle
-	ips["tags"] = ds[0].Tags
-	ret = append(ret, ips)
-	return ret
+	return p
 }
 
 func resourceStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -390,11 +390,11 @@ func getInstanceParams(params *packngo.SpotMarketRequestInstanceParameters) Inst
 		"description":      params.Description,
 		"features":         params.Features,
 		"locked":           params.Locked,
-		"project_ssh_keys": params.BillingCycle,
-		"user_ssh_keys":    params.BillingCycle,
+		"project_ssh_keys": params.ProjectSSHKeys,
+		"user_ssh_keys":    params.UserSSHKeys,
 		"userdata":         params.UserData,
 		"customdata":       params.CustomData,
-		"ipxe_script_url":  params.BillingCycle,
+		"ipxe_script_url":  params.IPXEScriptURL,
 		"tags":             params.Tags,
 	}}
 	if params.TerminationTime != nil {

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -128,7 +128,7 @@ resource "metal_spot_market_request" "request" {
   instance_parameters {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
-    operating_system = "ubuntu_18_04"
+    operating_system = "ubuntu_20_04"
     plan             = "c3.medium.x86"
   }
 }`, name)

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -29,6 +29,11 @@ func TestAccMetalSpotMarketRequest_Basic(t *testing.T) {
 						"data.metal_spot_market_request.dreq", "device_ids.#", "1"),
 				),
 			},
+			{
+				ResourceName:      "metal_spot_market_request.request",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -145,9 +145,10 @@ func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
 				Config: testAccCheckMetalSpotMarketRequestConfig_import(rs),
 			},
 			{
-				ResourceName:      "metal_spot_market_request.request",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "metal_spot_market_request.request",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_parameters", "wait_for_devices"},
 			},
 		},
 	})

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/packethost/packngo"
 )
 
+func testAccCheckMetalSpotMarketRequestConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "metal_project" "test" {
+  name = "tfacc-spot_market_request-%s"
+}
+
+data "metal_spot_market_price" "test" {
+  facility = "ewr1"
+  plan     = "baremetal_0"
+}
+
+data "metal_spot_market_request" "dreq" {
+	request_id = metal_spot_market_request.request.id
+}
+
+resource "metal_spot_market_request" "request" {
+  project_id       = "${metal_project.test.id}"
+  max_bid_price    = data.metal_spot_market_price.test.price * 1.2
+  facilities       = ["ewr1"]
+  devices_min      = 1
+  devices_max      = 1
+  wait_for_devices = true
+
+  instance_parameters {
+    hostname         = "tfacc-testspot"
+    billing_cycle    = "hourly"
+    operating_system = "ubuntu_18_04"
+    plan             = "baremetal_0"
+  }
+}`, name)
+}
+
 func TestAccMetalSpotMarketRequest_Basic(t *testing.T) {
 	var key packngo.SpotMarketRequest
 	rs := acctest.RandString(10)
@@ -28,11 +60,6 @@ func TestAccMetalSpotMarketRequest_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.metal_spot_market_request.dreq", "device_ids.#", "1"),
 				),
-			},
-			{
-				ResourceName:      "metal_spot_market_request.request",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -79,25 +106,21 @@ func testAccCheckMetalSpotMarketRequestExists(n string, key *packngo.SpotMarketR
 	}
 }
 
-func testAccCheckMetalSpotMarketRequestConfig_basic(name string) string {
+func testAccCheckMetalSpotMarketRequestConfig_import(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
   name = "tfacc-spot_market_request-%s"
 }
 
 data "metal_spot_market_price" "test" {
-  facility = "ewr1"
-  plan     = "baremetal_0"
-}
-
-data "metal_spot_market_request" "dreq" {
-	request_id = metal_spot_market_request.request.id
+  facility = "sv15"
+  plan     = "c3.medium.x86"
 }
 
 resource "metal_spot_market_request" "request" {
-  project_id       = "${metal_project.test.id}"
+  project_id       = metal_project.test.id
   max_bid_price    = data.metal_spot_market_price.test.price * 1.2
-  facilities       = ["ewr1"]
+  facilities       = ["sv15"]
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
@@ -106,7 +129,26 @@ resource "metal_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_18_04"
-    plan             = "baremetal_0"
+    plan             = "c3.medium.x86"
   }
 }`, name)
+}
+
+func TestAccMetalSpotMarketRequest_Import(t *testing.T) {
+	rs := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMetalSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckMetalSpotMarketRequestConfig_import(rs),
+			},
+			{
+				ResourceName:      "metal_spot_market_request.request",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }


### PR DESCRIPTION
This is the last resource to implement importers from the list originally prepared at https://github.com/packethost/terraform-provider-packet/issues/51.

I've also added import documentation for some resources that supported it but did not document it.  (I did not attempt to document the resources with composite keys).