### PR TITLE
Add datasource metal_reserved_ip_block, docs and a test

### DIFF
--- a/docs/data-sources/reserved_ip_block.md
+++ b/docs/data-sources/reserved_ip_block.md
@@ -35,9 +35,9 @@ resource "metal_device" "www" {
 
 ## Argument Reference
 
-You should pass either `block_id`, or both `project_id` and `ip_address`.
+You should pass either `id`, or both `project_id` and `ip_address`.
 
-* `block_id` - (Required) UUID of the IP address block to look up
+* `id` - (Required) UUID of the IP address block to look up
 * `project_id` - (Required) UUID of the project where the searched block should be
 * `ip_address` - (Required) Block containing this IP address will be returned
 

--- a/docs/data-sources/reserved_ip_block.md
+++ b/docs/data-sources/reserved_ip_block.md
@@ -1,0 +1,47 @@
+---
+page_title: "Equinix Metal: reserved_ip_block"
+subcategory: ""
+description: |-
+Look up an IP address block
+---
+
+# metal\_reserved\_ip\_block
+
+Use this data source to find IP address blocks in Equinix Metal. You can use IP address or a block ID for lookup.
+
+## Example Usage
+
+Look up an IP address for a domain name, then use the IP to look up the containing IP block and run a device with IP address from the block:
+
+```hcl
+data "dns_a_record_set" "www" {
+  host = "www.example.com"
+}
+
+data "metal_reserved_ip_block" "www" {
+  project_id = local.my_project_id
+  address = data.dns_a_record_set.www.addrs[0]
+}
+
+resource "metal_device" "www" {
+  project_id = local.my_project_id
+  [...]
+  ip_address {
+    type = "public_ipv4"
+    reservation_ids = [data.metal_reserved_ip_block.www.id]
+  }
+}
+```
+
+## Argument Reference
+
+You should pass either `block_id`, or both `project_id` and `ip_address`.
+
+* `block_id` - (Required) UUID of the IP address block to look up
+* `project_id` - (Required) UUID of the project where the searched block should be
+* `ip_address` - (Required) Block containing this IP address will be returned
+
+## Attributes Reference
+
+This datasource exposes the same attributes as the [metal_reserved_ip_block resource](../resources/reserved_ip_block.md).
+

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -166,7 +166,7 @@ The `ip_address` block has 3 fields:
 
 * `type` - One of [`private_ipv4`, `public_ipv4`, `public_ipv6`]
 * `cidr` - CIDR suffix for IP address block to be assigned, i.e. amount of addresses.
-* `reservation_ids` - String of UUID of [IP block reservations](reserved_ip_block.md) from which the public IPv4 address should be taken.
+* `reservation_ids` - List of UUIDs of [IP block reservations](reserved_ip_block.md) from which the public IPv4 address should be taken.
 
 You can supply one `ip_address` block per IP address type. If you use the `ip_address` you must always pass a block for `private_ipv4`.
 

--- a/metal/datasource_metal_precreated_ip_block.go
+++ b/metal/datasource_metal_precreated_ip_block.go
@@ -1,10 +1,7 @@
 package metal
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func dataSourceMetalPreCreatedIPBlock() *schema.Resource {
@@ -61,74 +58,4 @@ func dataSourceMetalPreCreatedIPBlock() *schema.Resource {
 		Read:   dataSourceMetalReservedIPBlockRead,
 		Schema: s,
 	}
-}
-
-func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
-	projectID := d.Get("project_id").(string)
-	ips, _, err := client.ProjectIPs.List(projectID, nil)
-	if err != nil {
-		return err
-	}
-	ipv := d.Get("address_family").(int)
-	public := d.Get("public").(bool)
-	global := d.Get("global").(bool)
-
-	if !public && global {
-		return fmt.Errorf("Private (non-public) global IP address blocks are not supported in Equinix Metal")
-	}
-
-	fval, fok := d.GetOk("facility")
-	mval, mok := d.GetOk("metro")
-	if (fok || mok) && global {
-		return fmt.Errorf("You can't specify facility for global IP block - addresses from global blocks can be assigned to devices across several locations")
-	}
-
-	if fok && mok {
-		return fmt.Errorf("You can't specify both facility and metro.")
-	}
-
-	if fok {
-		// lookup of not-global block
-		facility := fval.(string)
-		for _, ip := range ips {
-			if ip.Public == public && ip.AddressFamily == ipv && facility == ip.Facility.Code {
-				if err := loadBlock(d, &ip); err != nil {
-					return err
-				}
-				break
-			}
-		}
-	} else if mok {
-		// lookup of not-global block
-		metro := mval.(string)
-		for _, ip := range ips {
-			if ip.Metro == nil {
-				continue
-			}
-			if ip.Public == public && ip.AddressFamily == ipv && metro == ip.Metro.Code {
-				if err := loadBlock(d, &ip); err != nil {
-					return err
-				}
-				break
-			}
-		}
-	} else {
-		// lookup of global block
-		for _, ip := range ips {
-			blockGlobal := getGlobalBool(&ip)
-			if ip.Public == public && ip.AddressFamily == ipv && blockGlobal {
-				if err := loadBlock(d, &ip); err != nil {
-					return err
-				}
-				break
-			}
-		}
-
-	}
-	if d.Get("cidr_notation") == "" {
-		return fmt.Errorf("Could not find matching reserved block, all IPs were %v", ips)
-	}
-	return nil
-
 }

--- a/metal/datasource_metal_reserved_ip_block.go
+++ b/metal/datasource_metal_reserved_ip_block.go
@@ -1,0 +1,169 @@
+package metal
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourceMetalReservedIPBlock() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMetalReservedIPBlockRead,
+		Schema: map[string]*schema.Schema{
+			"block_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "ID of the block to look up",
+				ConflictsWith: []string{"project_id", "address"},
+				Computed:      true,
+			},
+			"project_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Description:   "ID of the project where the searched block should be",
+				ConflictsWith: []string{"block_id"},
+			},
+			"ip_address": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Description:   "Find block containing this IP address in given project",
+				ConflictsWith: []string{"block_id"},
+			},
+
+			"global": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Addresses from block are attachable in all locations",
+			},
+			"public": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Addresses from public block are routeable from the Internet",
+			},
+			"facility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Facility of the block. (for non-global blocks)",
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Metro of the block (for non-global blocks)",
+			},
+			"address_family": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "4 or 6",
+			},
+			"address": {
+				// I honestly don't know what this "address" is. Maybe next available?
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cidr_notation": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "CIDR notation of the looked up block",
+			},
+			"cidr": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Length of CIDR prefix of the block as integer",
+			},
+			"gateway": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address of gateway for the block",
+			},
+			"netmask": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Mask in decimal notation, e.g. 255.255.255.0",
+			},
+			"network": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Network IP address portion of the block specification",
+			},
+			"manageable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"management": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"quantity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Address type, one of public_ipv4, public_ipv6 and private_ipv4",
+			},
+		},
+	}
+}
+
+func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	blockId, blockIdOk := d.GetOk("block_id")
+	projectId, projectIdOk := d.GetOk("project_id")
+	address, addressOk := d.GetOk("ip_address")
+
+	if !(blockIdOk || (projectIdOk && addressOk)) {
+		return fmt.Errorf("You must specify either block_id or project_id and ip_address")
+	}
+	if blockIdOk {
+		block, _, err := client.ProjectIPs.Get(
+			blockId.(string),
+			&packngo.GetOptions{Includes: []string{"facility", "project", "metro"}},
+		)
+		if err != nil {
+			return err
+		}
+		return loadBlock(d, block)
+	}
+	// we search by project_id and ip_address
+	addressStr := address.(string)
+	lookupAddress := net.ParseIP(addressStr)
+	if lookupAddress == nil {
+		return fmt.Errorf("%s is not a valid ip_address", addressStr)
+	}
+
+	blocks, _, err := client.ProjectIPs.List(projectId.(string),
+		&packngo.GetOptions{Includes: []string{"facility", "project", "metro"}},
+	)
+	if err != nil {
+		return err
+	}
+	for _, b := range blocks {
+		cidr := fmt.Sprintf("%s/%d", b.Network, b.CIDR)
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("CIDR expression of an Equinix Metal IP Block could not be parsed: %s. Please report this in a GitHub issue", cidr)
+		}
+
+		if ipNet.Contains(lookupAddress) {
+			d.Set("block_id", b.ID)
+			return loadBlock(d, &b)
+		}
+	}
+	return fmt.Errorf("Could not find matching reserved block, all blocks were \n%s", listOfCidrs(blocks))
+
+}
+
+func listOfCidrs(blocks []packngo.IPAddressReservation) string {
+	cidrs := []string{}
+	for _, b := range blocks {
+		cidrs = append(cidrs, fmt.Sprintf("%s/%d", b.Network, b.CIDR))
+	}
+	return strings.Join(cidrs, "\n")
+
+}

--- a/metal/datasource_metal_reserved_ip_block.go
+++ b/metal/datasource_metal_reserved_ip_block.go
@@ -13,7 +13,7 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceMetalReservedIPBlockRead,
 		Schema: map[string]*schema.Schema{
-			"block_id": {
+			"id": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "ID of the block to look up",
@@ -25,13 +25,13 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				Description:   "ID of the project where the searched block should be",
-				ConflictsWith: []string{"block_id"},
+				ConflictsWith: []string{"id"},
 			},
 			"ip_address": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "Find block containing this IP address in given project",
-				ConflictsWith: []string{"block_id"},
+				ConflictsWith: []string{"id"},
 			},
 
 			"global": {
@@ -113,12 +113,12 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 
-	blockId, blockIdOk := d.GetOk("block_id")
+	blockId, blockIdOk := d.GetOk("id")
 	projectId, projectIdOk := d.GetOk("project_id")
 	address, addressOk := d.GetOk("ip_address")
 
 	if !(blockIdOk || (projectIdOk && addressOk)) {
-		return fmt.Errorf("You must specify either block_id or project_id and ip_address")
+		return fmt.Errorf("You must specify either id or project_id and ip_address")
 	}
 	if blockIdOk {
 		block, _, err := client.ProjectIPs.Get(
@@ -151,7 +151,7 @@ func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}
 		}
 
 		if ipNet.Contains(lookupAddress) {
-			d.Set("block_id", b.ID)
+			d.Set("id", b.ID)
 			return loadBlock(d, &b)
 		}
 	}

--- a/metal/datasource_metal_reserved_ip_block_test.go
+++ b/metal/datasource_metal_reserved_ip_block_test.go
@@ -27,7 +27,7 @@ data "metal_reserved_ip_block" "test" {
 }
 
 data "metal_reserved_ip_block" "test_id" {
-	block_id  = metal_reserved_ip_block.test.id
+	id  = metal_reserved_ip_block.test.id
 }
 
 `, name)

--- a/metal/datasource_metal_reserved_ip_block_test.go
+++ b/metal/datasource_metal_reserved_ip_block_test.go
@@ -1,0 +1,60 @@
+package metal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func testAccDataSourceMetalReservedIPBlockConfig_Basic(name string) string {
+	return fmt.Sprintf(`
+resource "metal_project" "foobar" {
+	name = "tfacc-reserved_ip_block-%s"
+}
+
+resource "metal_reserved_ip_block" "test" {
+	project_id  = metal_project.foobar.id
+	metro       = "sv"
+	type        = "public_ipv4"
+	quantity    = 2
+}
+
+data "metal_reserved_ip_block" "test" {
+	project_id  = metal_project.foobar.id
+    ip_address  = cidrhost(metal_reserved_ip_block.test.cidr_notation,1)
+}
+
+data "metal_reserved_ip_block" "test_id" {
+	block_id  = metal_reserved_ip_block.test.id
+}
+
+`, name)
+}
+
+func TestAccDataSourceMetalReservedIPBlock_Basic(t *testing.T) {
+
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMetalReservedIPBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceMetalReservedIPBlockConfig_Basic(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"metal_reserved_ip_block.test", "id",
+						"data.metal_reserved_ip_block.test", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"metal_reserved_ip_block.test", "cidr_notation",
+						"data.metal_reserved_ip_block.test_id", "cidr_notation",
+					),
+				),
+			},
+		},
+	})
+}

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -47,6 +47,7 @@ func Provider() terraform.ResourceProvider {
 			"metal_device_bgp_neighbors": dataSourceMetalDeviceBGPNeighbors(),
 			"metal_project":              dataSourceMetalProject(),
 			"metal_project_ssh_key":      dataSourceMetalProjectSSHKey(),
+			"metal_reserved_ip_block":    dataSourceMetalReservedIPBlock(),
 			"metal_spot_market_request":  dataSourceMetalSpotMarketRequest(),
 			"metal_volume":               dataSourceMetalVolume(),
 			"metal_virtual_circuit":      dataSourceMetalVirtualCircuit(),


### PR DESCRIPTION
This PR adds a datasource metal_reserved_ip_block, which can be used to look up an IP address block based on an IP address, or by the block ID. 

Like
https://registry.terraform.io/providers/linode/linode/latest/docs/data-sources/networking_ip
https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/data-sources/lb_ip

We should think what we do with the metal_precreated_ip_block, which filters IP blocks by facility, metro, addr family etc. Not sure if it's useful. Is there a way to find out?

Fixes #68 

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>