### PR TITLE
add metro field to data source metal_connection (facility now optional)

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -26,6 +26,7 @@ data "metal_connection" "example" {
 * `description` - Description of the connection resource
 * `name` - Name of the connection resource
 * `facility` - Slug of a facility to which the connection belongs
+* `metro` - Slug of a metro to which the connection belongs
 * `organization_id` - ID of organization to which the connection belongs
 * `status` - Status of the connection
 * `token` - Fabric Token for the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)

--- a/metal/datasource_metal_connection.go
+++ b/metal/datasource_metal_connection.go
@@ -83,6 +83,11 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Description: "Slug of a facility to which the connection belongs",
 			},
+			"metro": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Slug of a metro to which the connection belongs",
+			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -102,7 +107,7 @@ func dataSourceMetalConnection() *schema.Resource {
 				Type:        schema.TypeList,
 				Elem:        connectionPortSchema(),
 				Computed:    true,
-				Description: " List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)",
+				Description: "List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)",
 			},
 		},
 	}
@@ -135,7 +140,7 @@ func dataSourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) err
 
 	conn, _, err := client.Connections.Get(
 		connId,
-		&packngo.GetOptions{Includes: []string{"organization", "facility"}})
+		&packngo.GetOptions{Includes: []string{"organization", "facility", "metro"}})
 	if err != nil {
 		return err
 	}
@@ -146,7 +151,12 @@ func dataSourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("description", conn.Description)
 	d.Set("status", conn.Status)
 	d.Set("redundancy", conn.Redundancy)
-	d.Set("facility", conn.Facility.Code)
+	if conn.Facility != nil {
+		d.Set("facility", conn.Facility.Code)
+	}
+	if conn.Metro != nil {
+		d.Set("metro", conn.Metro.Code)
+	}
 	d.Set("token", conn.Token)
 	d.Set("type", conn.Type)
 	d.Set("speed", conn.Speed)


### PR DESCRIPTION
Adds missing `metro` field for data source metal_connection resources.

Makes metal_connection safe for null facility (if that should be returned).