### PR TITLE
remove deprecation warning from metal_device.facility

### DIFF
--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -98,7 +98,6 @@ func resourceMetalDevice() *schema.Resource {
 					}
 					return false
 				},
-				Deprecated:    "Use metro attribute instead",
 				ConflictsWith: []string{"metro"},
 			},
 			"ip_address": {


### PR DESCRIPTION
This deprecation notice was accidentally added, facilities have never
been deprecated.

Fixes #79

Signed-off-by: Marques Johansson <mjohansson@equinix.com>