### PR TITLE
Add datasource metal_hardware_reservation and docs

### DIFF
--- a/docs/data-sources/hardware_reservation.md
+++ b/docs/data-sources/hardware_reservation.md
@@ -1,0 +1,36 @@
+---
+page_title: "Equinix Metal: metal_hardware_reservation"
+subcategory: ""
+description: |-
+  Retrieve Equinix Metal Hardware Reservation
+---
+
+# metal_hardware_reservation
+
+Use this data source to retrieve a [hardware reservation resource from Equinix Metal](https://metal.equinix.com/developers/docs/deploy/reserved/).
+
+## Example Usage
+
+```hcl
+data "hardware_reservation" "example" {
+  id     = "4347e805-eb46-4699-9eb9-5c116e6a0172"
+}
+```
+
+## Argument Reference
+
+* `id` - (Required) ID of the hardware reservation
+
+## Attributes Reference
+
+* `id` - ID of the hardware reservation to look up
+* `short_id` - Reservation short ID
+* `project_id` - UUID of project this reservation is scoped to
+* `device_id` - UUID of device occupying the reservation
+* `plan` - Plan type for the reservation
+* `facility` - Plan type for the reservation
+* `provisionable` - Flag indicating whether the reservation can be currently used to create a device
+* `spare` - Flag indicating whether the reservation is spare (@displague help),
+* `switch_uuid` - UUID of switch (@displague help)
+* `intervals` - (@displague help)
+* `current_period` - (@displague help)

--- a/docs/data-sources/hardware_reservation.md
+++ b/docs/data-sources/hardware_reservation.md
@@ -9,17 +9,26 @@ description: |-
 
 Use this data source to retrieve a [hardware reservation resource from Equinix Metal](https://metal.equinix.com/developers/docs/deploy/reserved/).
 
+You can look up hardware reservation by its ID or by ID of device which occupies it.
+
 ## Example Usage
 
 ```hcl
+// lookup by ID
 data "hardware_reservation" "example" {
   id     = "4347e805-eb46-4699-9eb9-5c116e6a0172"
+}
+
+// lookup by device ID
+data "hardware_reservation" "example_by_device_id" {
+  device_id     = "ff85aa58-c106-4624-8f1c-7c64554047ea"
 }
 ```
 
 ## Argument Reference
 
-* `id` - (Required) ID of the hardware reservation
+* `id` - ID of the hardware reservation
+* `device_id` - UUID of device occupying the reservation
 
 ## Attributes Reference
 
@@ -29,8 +38,6 @@ data "hardware_reservation" "example" {
 * `device_id` - UUID of device occupying the reservation
 * `plan` - Plan type for the reservation
 * `facility` - Plan type for the reservation
-* `provisionable` - Flag indicating whether the reservation can be currently used to create a device
-* `spare` - Flag indicating whether the reservation is spare (@displague help),
-* `switch_uuid` - UUID of switch (@displague help)
-* `intervals` - (@displague help)
-* `current_period` - (@displague help)
+* `provisionable` - Flag indicating whether the reserved server is provisionable or not. Spare devices can't be provisioned unless they are activated first
+* `spare` -  Flag indicating whether the Hardware Reservation is a spare. Spare Hardware Reservations are used when a Hardware Reservations requires service from Metal Equinix
+* `switch_uuid` - Switch short ID, can be used to determine if two devices are connected to the same switch

--- a/metal/datasource_metal_hardware_reservation.go
+++ b/metal/datasource_metal_hardware_reservation.go
@@ -86,7 +86,7 @@ func dataSourceMetalHardwareReservationRead(d *schema.ResourceData, meta interfa
 			return err
 		}
 		if d.HardwareReservation == nil {
-			return fmt.Errorf("Device %s is not in a hardware reservation")
+			return fmt.Errorf("Device %s is not in a hardware reservation", deviceId)
 		}
 		hr = d.HardwareReservation
 

--- a/metal/datasource_metal_hardware_reservation.go
+++ b/metal/datasource_metal_hardware_reservation.go
@@ -1,0 +1,102 @@
+package metal
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourceMetalHardwareReservation() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMetalHardwareReservationRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "ID of the hardware reservation to look up",
+			},
+			"short_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reservation short ID",
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of project this reservation is scoped to",
+			},
+			"device_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of device occupying the reservation",
+			},
+			"plan": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Plan type for the reservation",
+			},
+			"facility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Plan type for the reservation",
+			},
+			"provisionable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Flag indicating whether the reservation can be currently used to create a device",
+			},
+			"spare": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Flag indicating whether the reservation is spare (@displague help),",
+			},
+			"switch_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of switch (@displague help)",
+			},
+			"intervals": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "(@displague help)",
+			},
+			"current_period": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "(@displague help)",
+			},
+		},
+	}
+}
+
+func dataSourceMetalHardwareReservationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	hrId := d.Get("id").(string)
+
+	hr, _, err := client.HardwareReservations.Get(
+		hrId,
+		&packngo.GetOptions{Includes: []string{"project", "facility", "device"}})
+	if err != nil {
+		return err
+	}
+	deviceId := ""
+	if hr.Device != nil {
+		deviceId = hr.Device.ID
+	}
+
+	m := map[string]interface{}{
+		"short_id":       hr.ShortID,
+		"project_id":     hr.Project.ID,
+		"device_id":      deviceId,
+		"plan":           hr.Plan.Slug,
+		"facility":       hr.Facility.Code,
+		"provisionable":  hr.Provisionable,
+		"spare":          hr.Spare,
+		"switch_uuid":    hr.SwitchUUID,
+		"intervals":      hr.Intervals,
+		"current_period": hr.CurrentPeriod,
+	}
+
+	d.SetId(hr.ID)
+	return setMap(d, m)
+}

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -35,6 +35,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"metal_hardware_reservation": dataSourceMetalHardwareReservation(),
 			"metal_metro":                dataSourceMetalMetro(),
 			"metal_facility":             dataSourceMetalFacility(),
 			"metal_connection":           dataSourceMetalConnection(),


### PR DESCRIPTION
fixes #86 

This PR adds datasource metal_hardware_reservation. 

@displague please let me know if we should allow to look up the reservation by other params than the ID.

Also, please fix some docstrings in the code, I wasn't sure about the purpose of some parameters. Grep for "@displague"

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>