### PR TITLE
Fix typos in the new guides

### DIFF
--- a/docs/guides/migration_guide_facilities_to_metros_devices.md
+++ b/docs/guides/migration_guide_facilities_to_metros_devices.md
@@ -8,7 +8,7 @@ description: |-
 
 In April 2021, Equinix Metal rolled out a new location concept - [metros](https://feedback.equinixmetal.com/changelog/new-metros-feature-live). A metro is an Equinix-wide concept for data centers which are grouped together geographically. Data centers within a metro share capacity and networking features. You can read more about metros at https://metal.equinix.com/developers/docs/locations/metros/.
 
-Until the metros introduction, resource deployment location used to be controlled by "facilty" - single data center with location code like "sv15" or "ny5". Metros group the facilities, and e.g. metro "sv" contains facility "sv15". If you specify a metro when creating a resource, it will be deployed to one of the facilities in the metro group. You can then find the deployed facility from the a read-only attribute of the resource.
+Until the metros introduction, resource deployment location used to be controlled by "facilty" - single data center with location code like "sv15" or "ny5". Metros group the facilities, so e.g. metro "sv" contains facility "sv15". If you specify a metro when creating a resource, it will be deployed to one of the facilities in the metro group. You can then find the deployed facility from a read-only attribute of the resource.
 
 
 ## Changing your Terraform templates to use metros instead of facilities
@@ -48,9 +48,9 @@ resource "metal_device" "node" {
 }
 ```
 
-To test that the change didn't taint the state, and that the device will not be re-created, you can check if `terraform plan` reports no differences. The terraform state should be up to date as long as the facility in which the device was deployed was contained within the metro.
+To test that the change didn't taint the state, and that the device will not be re-created, you can check if `terraform plan` reports any differences. The terraform state should be up to date as long as the facility in which the device was deployed was contained within the metro.
 
-If the plan diff is not empty, you might have set a metro not containing the facility to which the device was deployed. This might happen if you've used more facilities in the `facilities` list, or you have used "any" facility.
+If the plan diff is not empty, you might have used a metro not containing the facility to which the device was deployed. This might happen if you've used more facilities in the `facilities` list, or you have used "any" facility.
 
 You can find out the deployed facility, and the containing metro by examining the terraform state of the `metal_device` resource:
 

--- a/docs/guides/migration_guide_facilities_to_metros_devices.md
+++ b/docs/guides/migration_guide_facilities_to_metros_devices.md
@@ -50,7 +50,7 @@ resource "metal_device" "node" {
 
 To test that the change didn't taint the state, and that the device will not be re-created, you can check if `terraform plan` reports any differences. The terraform state should be up to date as long as the facility in which the device was deployed was contained within the metro.
 
-If the plan diff is not empty, you might have used a metro not containing the facility to which the device was deployed. This might happen if you've used more facilities in the `facilities` list, or you have used "any" facility.
+If the plan diff is not empty, you might have used a metro not containing the facility to which the device was deployed. This might happen if you've used more facilities in the `facilities` list, or you have used the special "any" facility.
 
 You can find out the deployed facility, and the containing metro by examining the terraform state of the `metal_device` resource:
 

--- a/docs/guides/migration_guide_facilities_to_metros_devices.md
+++ b/docs/guides/migration_guide_facilities_to_metros_devices.md
@@ -8,7 +8,7 @@ description: |-
 
 In April 2021, Equinix Metal rolled out a new location concept - [metros](https://feedback.equinixmetal.com/changelog/new-metros-feature-live). A metro is an Equinix-wide concept for data centers which are grouped together geographically. Data centers within a metro share capacity and networking features. You can read more about metros at https://metal.equinix.com/developers/docs/locations/metros/.
 
-Until the metros introduction, resource deployment location used to be controlled by "facilty" - single data center with location code like "sv15" or "ny5". Metros group the facilities, so e.g. metro "sv" contains facility "sv15". If you specify a metro when creating a resource, it will be deployed to one of the facilities in the metro group. You can then find the deployed facility from a read-only attribute of the resource.
+Before the introduction of metros, resources were deployed to a single `facility` location.  When provisioning `metal_device` resources, the facility could be chosen by Equinix Metal with a user-supplied list of `facilities`, or a wildcard `any` facility.  The individual facility locations use a code like "sv15" or "ny5". Metros group facilities. For example, metro "sv" contains the "sv15" facility, among others. If you specify a metro when creating a resource, it will be deployed to one of the facilities in the metro group. You can then find the deployed facility using a read-only attribute of the resource (e.g. `deployed_facility` for `metal_device` resources).
 
 
 ## Changing your Terraform templates to use metros instead of facilities
@@ -65,4 +65,3 @@ $ terraform state show metal_device.node | grep metro
 ```
 
 You should then set the existing metro in your Terraform templates.
-

--- a/docs/guides/migration_guide_packet.md
+++ b/docs/guides/migration_guide_packet.md
@@ -17,7 +17,7 @@ Before starting to migrate your Terraform templates, please upgrade
 
 ## Fast migration with replace-provider and sed
 
-Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substition task, basically replacing `packet_` with `metal_` wherever possible, and fixing the provider source reference.
+Just like the Terraform HCL templates, the Terraform state is a file containing resource names and their attributes in structured text. We can attempt the migration as a text substitution task, basically replacing `packet_` with `metal_` wherever possible, and fixing the provider source reference.
 
 It's a good idea to make a backup of the whole Terraform directory before doing this.
 
@@ -71,7 +71,7 @@ $ sed -i 's/packet_/metal_/g' terraform.tfstate
 
 The example template would now look as:
 
-```
+```hcl-terraform
 terraform {
   required_providers {
     metal = {
@@ -97,11 +97,11 @@ If the plan is not empty, it means that some resources can not be simply read fo
 
 ## Migrating one resource at a time
 
-We can use terraform state and import to achieve transition without destroying existing resources.
+We can use `$ terraform state` and `$ terraform import` to achieve transition without destroying existing resources.
 
 ### Existing infrastructure
 
-We assume to have infrastructure created with provider packethost/packet with a device and IP reservation. The HCL looks like:
+We assume to have infrastructure created with provider packethost/packet with a device and an IP reservation. The HCL looks like:
 
 ```hcl-terraform
 terraform {

--- a/docs/guides/migration_guide_packet.md
+++ b/docs/guides/migration_guide_packet.md
@@ -97,7 +97,7 @@ If the plan is not empty, it means that some resources can not be simply read fo
 
 ## Migrating one resource at a time
 
-We can use `$ terraform state` and `$ terraform import` to achieve transition without destroying existing resources.
+We can use `terraform state` and `terraform import` to achieve transition without destroying existing resources.
 
 ### Existing infrastructure
 
@@ -235,5 +235,4 @@ We then need to install the equinix/metal provider by running `$ terraform init`
 When we run `$ terraform plan` to verify that migration was successful, terraform might warn that some resource attributes from templates are not aligned with imported state. It's because not all of the resource attribute can be computed, for example the `ip_address` blocks in packet_device are user-defined and will result to a non-empty diff against downloaded imported state.
 
 In case of the `ip_address`, a consequent `$ terraform apply` will update the local state without changing the upstream resource, but if an attribute causes an upstream update, you will need to resolve it manually, either changing your template, or letting Terraform change the resource upstream.
-
 


### PR DESCRIPTION
I went trough the rendered guides in TF doc site:
https://registry.terraform.io/providers/equinix/metal/latest/docs/guides/migration_guide_packet
.. and fixed some typos.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>