### PR TITLE
Cast metro slug to lower case

### DIFF
--- a/metal/datasource_metal_connection.go
+++ b/metal/datasource_metal_connection.go
@@ -92,6 +92,7 @@ func dataSourceMetalConnection() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Slug of a metro to which the connection belongs",
+				StateFunc:   toLower,
 			},
 			"token": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_device.go
+++ b/metal/datasource_metal_device.go
@@ -42,8 +42,9 @@ func dataSourceMetalDevice() *schema.Resource {
 				Computed: true,
 			},
 			"metro": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				StateFunc: toLower,
 			},
 			"plan": {
 				Type:     schema.TypeString,

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -25,6 +25,7 @@ func dataSourceMetalFacility() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "This facility's metro code.",
 				Computed:    true,
+				StateFunc:   toLower,
 			},
 			"features": {
 				Type:        schema.TypeList,

--- a/metal/datasource_metal_ip_block_ranges.go
+++ b/metal/datasource_metal_ip_block_ranges.go
@@ -21,8 +21,9 @@ func dataSourceMetalIPBlockRanges() *schema.Resource {
 				Optional: true,
 			},
 			"metro": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: toLower,
 			},
 			"public_ipv4": {
 				Type:     schema.TypeList,

--- a/metal/datasource_metal_reserved_ip_block.go
+++ b/metal/datasource_metal_reserved_ip_block.go
@@ -53,6 +53,7 @@ func dataSourceMetalReservedIPBlock() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Metro of the block (for non-global blocks)",
+				StateFunc:   toLower,
 			},
 			"address_family": {
 				Type:        schema.TypeInt,

--- a/metal/datasource_metal_spot_market_price.go
+++ b/metal/datasource_metal_spot_market_price.go
@@ -20,6 +20,7 @@ func dataSourceSpotMarketPrice() *schema.Resource {
 				Type:          schema.TypeString,
 				ConflictsWith: []string{"facility"},
 				Optional:      true,
+				StateFunc:     toLower,
 			},
 			"plan": {
 				Type:     schema.TypeString,

--- a/metal/datasource_metal_spot_market_request.go
+++ b/metal/datasource_metal_spot_market_request.go
@@ -48,6 +48,7 @@ func dataSourceMetalSpotMarketRequest() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Metro where devices should be created.",
 				Computed:    true,
+				StateFunc:   toLower,
 			},
 			"project_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_vlan.go
+++ b/metal/datasource_metal_vlan.go
@@ -41,6 +41,7 @@ func dataSourceMetalVlan() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"vlan_id", "facility"},
 				Description:   "Metro where the VLAN is deployed",
+				StateFunc:     toLower,
 			},
 			"vlan_id": {
 				Type:          schema.TypeString,

--- a/metal/resource_metal_connection.go
+++ b/metal/resource_metal_connection.go
@@ -38,6 +38,7 @@ func resourceMetalConnection() *schema.Resource {
 				Description:   "Metro where to the connection will be created",
 				ConflictsWith: []string{"facility"},
 				ForceNew:      true,
+				StateFunc:     toLower,
 			},
 			"redundancy": {
 				// TODO: remove ForceNew and do Update, https://github.com/packethost/packngo/issues/270

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -78,6 +78,7 @@ func resourceMetalDevice() *schema.Resource {
 					}
 					return old == new
 				},
+				StateFunc: toLower,
 			},
 
 			"facilities": {

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -67,6 +67,7 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"facilities"},
+				StateFunc:     toLower,
 			},
 			"instance_parameters": {
 				Type:     schema.TypeList,

--- a/metal/resource_metal_vlan.go
+++ b/metal/resource_metal_vlan.go
@@ -56,6 +56,7 @@ func resourceMetalVlan() *schema.Resource {
 					}
 					return old == new
 				},
+				StateFunc: toLower,
 			},
 			"vxlan": {
 				Type:     schema.TypeInt,

--- a/metal/utils.go
+++ b/metal/utils.go
@@ -1,5 +1,7 @@
 package metal
 
+import "strings"
+
 func contains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {
@@ -18,4 +20,8 @@ func convertStringArr(ifaceArr []interface{}) []string {
 		arr = append(arr, v.(string))
 	}
 	return arr
+}
+
+func toLower(v interface{}) string {
+	return strings.ToLower(v.(string))
 }


### PR DESCRIPTION
fixes #118 

This PR uses StateFunc to cast metro attr to lower case in metro-usign resoruce and datasources. Metros are ambiguously specified in different docs in lower or upper case. The lowercasing will ensure that "SV" and "sv" can be used interchangeably. 


Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>