### PR TITLE
reserved_ip_block: add support for setting tags

### DIFF
--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -93,6 +93,7 @@ The following arguments are supported:
 * `facility` - (Optional) Facility where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4, conflicts with `metro`
 * `metro` - (Optional) Metro where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4, conflicts with `facility`
 * `description` - (Optional) Arbitrary description
+* `tags` - (Optional) String list of tags
 
 ## Attributes Reference
 
@@ -110,6 +111,7 @@ The following attributes are exported:
 * `address_family` - Address family as integer (4 or 6)
 * `public` - boolean flag whether addresses from a block are public
 * `global` - boolean flag whether addresses from a block are global (i.e. can be assigned in any facility)
+* `tags` - string list of tags
 
 Idempotent reference to a first "/32" address from a reserved block might look like this:
 

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -35,6 +35,7 @@ resource "metal_reserved_ip_block" "test" {
 	facility    = "ewr1"
 	type        = "public_ipv4"
 	quantity    = 2
+	tags        = ["Tag1", "Tag2"]
 }`, name)
 }
 
@@ -76,8 +77,6 @@ func TestAccMetalReservedIPBlock_Global(t *testing.T) {
 						"metal_reserved_ip_block.test", "public", "true"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "management", "false"),
-					resource.TestCheckResourceAttr(
-						"metal_reserved_ip_block.test", "tags.#", "2"),
 				),
 			},
 		},
@@ -108,6 +107,8 @@ func TestAccMetalReservedIPBlock_Public(t *testing.T) {
 						"metal_reserved_ip_block.test", "public", "true"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "management", "false"),
+					resource.TestCheckResourceAttr(
+						"metal_reserved_ip_block.test", "tags.#", "2"),
 				),
 			},
 		},
@@ -181,7 +182,6 @@ resource "metal_reserved_ip_block" "test" {
 	facility    = "ewr1"
 	type        = "public_ipv4"
 	quantity    = 2
-	tags        = ["Tag1", "Tag2"]
 }
 
 resource "metal_device" "test" {

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -76,6 +76,8 @@ func TestAccMetalReservedIPBlock_Global(t *testing.T) {
 						"metal_reserved_ip_block.test", "public", "true"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "management", "false"),
+					resource.TestCheckResourceAttr(
+						"metal_reserved_ip_block.test", "tags.#", "2"),
 				),
 			},
 		},
@@ -179,6 +181,7 @@ resource "metal_reserved_ip_block" "test" {
 	facility    = "ewr1"
 	type        = "public_ipv4"
 	quantity    = 2
+	tags        = ["Tag1", "Tag2"]
 }
 
 resource "metal_device" "test" {


### PR DESCRIPTION
The API allows specifying tags for reserved IP blocks, but this wasn't
exposed in the terraform resource.

Adding this makes it possible to create a IP reservation from terraform,
to be consumed by
https://github.com/equinix/cloud-provider-equinix-metal, for its control
plane elastic IP feature.

Closes #128.