### PR TITLE
feat: reinstall block for devices

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -161,6 +161,7 @@ The following arguments are supported:
 * `ip_address` - (Optional) A list of IP address types for the device (structure is documented below).
 * `wait_for_reservation_deprovision` - (Optional) Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 * `force_detach_volumes` - (Optional) Delete device even if it has volumes attached. Only applies for destroy action.
+* `reinstall` - (Optional) Whether the device should be reinstalled instead of destroyed when modifying user_data, custom_data, or operating system.
 
 The `ip_address` block has 3 fields:
 
@@ -172,6 +173,12 @@ You can supply one `ip_address` block per IP address type. If you use the `ip_ad
 
 To learn more about using the reserved IP addresses for new devices, see the examples in the [metal_reserved_ip_block](reserved_ip_block.md) documentation.
 
+The `reinstall` block has 3 fields:
+
+* `enabled` - Whether the provider should favour reinstall over destroy and create. Defaults to `false`.
+* `preserve_data` - (Optional) Whether the non-OS disks should be kept or wiped during reinstall. Defaults to `false`.
+* `deprovision_fast` - (Optional) Whether the OS disk should be filled with `00h` bytes before reinstall. Defaults to `false`.
+* 
 ## Attributes Reference
 
 The following attributes are exported:

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -1,6 +1,7 @@
 package metal
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -263,7 +265,7 @@ func resourceMetalDevice() *schema.Resource {
 				Description: "A string of the desired User Data for the device",
 				Optional:    true,
 				Sensitive:   true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 
 			"custom_data": {
@@ -271,7 +273,7 @@ func resourceMetalDevice() *schema.Resource {
 				Description: "A string of the desired Custom Data for the device",
 				Optional:    true,
 				Sensitive:   true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 
 			"ipxe_script_url": {
@@ -348,7 +350,61 @@ func resourceMetalDevice() *schema.Resource {
 				Default:     false,
 				ForceNew:    false,
 			},
+			"reinstall": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Description: "Whether the device should be reinstalled instead of destroyed",
+							Optional:    true,
+							Default:     false,
+						},
+						"deprovision_fast": {
+							Type:        schema.TypeBool,
+							Description: "Whether the OS disk should written with 0 bytes",
+							Optional:    true,
+							Default:     false,
+						},
+						"persist_data": {
+							Type:        schema.TypeBool,
+							Description: "Whether the non-OS disks should be kept or wiped during reinstall",
+							Optional:    true,
+							Default:     false,
+						},
+					},
+				},
+			},
 		},
+		CustomizeDiff: customdiff.Sequence(
+			customdiff.ForceNewIf("reinstall", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				reinstall, ok := d.GetOk("reinstall")
+
+				// Prior behaviour was to always destroy and create,
+				// so in the event we can't get the reinstall config; let's
+				// continue to do so.
+				if !ok {
+					return true
+				}
+
+				// We didn't get a reinstall configuration
+				reinstall_list, ok := reinstall.([]interface{})
+				if !ok {
+					return true
+				}
+
+				reinstall_config, ok := reinstall_list[0].(map[string]interface{})
+
+				// We didn't get a reinstall configuration
+				if !ok {
+					return true
+				}
+
+				return !reinstall_config["enabled"].(bool)
+			}),
+		),
 	}
 }
 
@@ -649,7 +705,53 @@ func resourceMetalDeviceUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 	}
+
+	if d.HasChange("operating_system") || d.HasChange("user_data") || d.HasChange("custom_data") {
+		reinstallOptions, err := getReinstallOptions(d)
+
+		if err != nil {
+			return friendlyError(err)
+		}
+
+		if _, err := client.Devices.Reinstall(d.Id(), &reinstallOptions); err != nil {
+			return friendlyError(err)
+		}
+	}
+
 	return resourceMetalDeviceRead(d, meta)
+}
+
+func getReinstallOptions(d *schema.ResourceData) (packngo.DeviceReinstallFields, error) {
+	reinstall_list, ok := d.Get("reinstall").([]interface{})
+
+	if !ok {
+		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
+	}
+
+	if len(reinstall_list) == 0 {
+		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
+	}
+
+	reinstall_config, ok := reinstall_list[0].(map[string]interface{})
+
+	if !ok {
+		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
+	}
+
+	preserveData, ok := reinstall_config["preserve_data"].(bool)
+	if !ok {
+		preserveData = false
+	}
+
+	deprovisionFast, ok := reinstall_config["preserve_data"].(bool)
+	if !ok {
+		deprovisionFast = false
+	}
+
+	return packngo.DeviceReinstallFields{
+		PreserveData:    preserveData,
+		DeprovisionFast: deprovisionFast,
+	}, nil
 }
 
 func resourceMetalDeviceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -364,7 +364,7 @@ func resourceMetalDevice() *schema.Resource {
 						},
 						"deprovision_fast": {
 							Type:        schema.TypeBool,
-							Description: "Whether the OS disk should written with 0 bytes",
+							Description: "Whether the OS disk should be filled with `00h` bytes before reinstall",
 							Optional:    true,
 							Default:     false,
 						},
@@ -739,7 +739,7 @@ func getReinstallOptions(d *schema.ResourceData) (packngo.DeviceReinstallFields,
 		preserveData = false
 	}
 
-	deprovisionFast, ok := reinstall_config["preserve_data"].(bool)
+	deprovisionFast, ok := reinstall_config["deprovision_fast"].(bool)
 	if !ok {
 		deprovisionFast = false
 	}

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -368,7 +368,7 @@ func resourceMetalDevice() *schema.Resource {
 							Optional:    true,
 							Default:     false,
 						},
-						"persist_data": {
+						"preserve_data": {
 							Type:        schema.TypeBool,
 							Description: "Whether the non-OS disks should be kept or wiped during reinstall",
 							Optional:    true,

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -734,19 +734,9 @@ func getReinstallOptions(d *schema.ResourceData) (packngo.DeviceReinstallFields,
 		return packngo.DeviceReinstallFields{}, fmt.Errorf("expected reinstall configuration and none available")
 	}
 
-	preserveData, ok := reinstall_config["preserve_data"].(bool)
-	if !ok {
-		preserveData = false
-	}
-
-	deprovisionFast, ok := reinstall_config["deprovision_fast"].(bool)
-	if !ok {
-		deprovisionFast = false
-	}
-
 	return packngo.DeviceReinstallFields{
-		PreserveData:    preserveData,
-		DeprovisionFast: deprovisionFast,
+		PreserveData:    reinstall_config["preserve_data"].(bool),
+		DeprovisionFast: reinstall_config["deprovision_fast"].(bool),
 	}, nil
 }
 

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -162,7 +162,7 @@ func TestAccMetalDevice_Metro(t *testing.T) {
 	})
 }
 func TestAccMetalDevice_Update(t *testing.T) {
-	var d1, d2, d3, d4, d5, d6 packngo.Device
+	var d1, d2, d3, d4, d5 packngo.Device
 	rs := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	r := "metal_device.test"
@@ -207,16 +207,10 @@ func TestAccMetalDevice_Update(t *testing.T) {
 				),
 			},
 			{
-
+				Config: testAccCheckMetalDeviceConfig_reinstall(rInt+4, rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalDeviceExists(r, &d5),
-				),
-			},
-			{
-				Config: testAccCheckMetalDeviceConfig_reinstall(rInt+5, rs),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetalDeviceExists(r, &d6),
-					testAccCheckMetalSameDevice(t, &d4, &d6),
+					testAccCheckMetalSameDevice(t, &d4, &d5),
 				),
 			},
 		},
@@ -483,25 +477,6 @@ resource "metal_device" "test" {
 `, projSuffix, rInt, rInt)
 }
 
-func testAccCheckMetalDeviceConfig_userdata(rInt int, projSuffix string) string {
-	return fmt.Sprintf(`
-resource "metal_project" "test" {
-    name = "tfacc-device-%s"
-}
-
-resource "metal_device" "test" {
-  hostname         = "tfacc-test-device-%d"
-  plan             = "t1.small.x86"
-  facilities       = ["sjc1"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${metal_project.test.id}"
-  tags             = ["%d"]
-  user_data = "#!/usr/bin/env sh\necho Hello\n"
-}
-`, projSuffix, rInt, rInt)
-}
-
 func testAccCheckMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
@@ -516,7 +491,7 @@ resource "metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
   tags             = ["%d"]
-  user_data = "#!/usr/bin/env sh\necho Changed\n"
+  user_data = "#!/usr/bin/env sh\necho Reinstall\n"
 
   reinstall {
 	  enabled = true

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -162,7 +162,7 @@ func TestAccMetalDevice_Metro(t *testing.T) {
 	})
 }
 func TestAccMetalDevice_Update(t *testing.T) {
-	var d1, d2, d3, d4, d6 packngo.Device
+	var d1, d2, d3, d4, d5, d6 packngo.Device
 	rs := acctest.RandString(10)
 	rInt := acctest.RandInt()
 	r := "metal_device.test"
@@ -206,12 +206,12 @@ func TestAccMetalDevice_Update(t *testing.T) {
 					testAccCheckMetalSameDevice(t, &d3, &d4),
 				),
 			},
-			// {
-			//
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckMetalDeviceExists(r, &d5),
-			// 	),
-			// },
+			{
+
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalDeviceExists(r, &d5),
+				),
+			},
 			{
 				Config: testAccCheckMetalDeviceConfig_reinstall(rInt+5, rs),
 				Check: resource.ComposeTestCheckFunc(

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -207,7 +207,7 @@ func TestAccMetalDevice_Update(t *testing.T) {
 				),
 			},
 			// {
-			// 	Config: testAccCheckMetalDeviceConfig_userdata(rInt+4, rs),
+			//
 			// 	Check: resource.ComposeTestCheckFunc(
 			// 		testAccCheckMetalDeviceExists(r, &d5),
 			// 	),

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
@@ -1,0 +1,75 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(ctx, d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(ctx, d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
@@ -1,0 +1,18 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
@@ -1,0 +1,62 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(ctx context.Context, old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(ctx context.Context, value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(ctx, old, new, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d.Get(key), meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
@@ -1,0 +1,42 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(ctx, old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(ctx context.Context, old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(ctx context.Context, value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(ctx, old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(ctx, val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,6 +55,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
@@ -135,6 +136,7 @@ github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes
 ## explicit
 github.com/hashicorp/terraform-plugin-sdk/v2/diag
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest
+github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema


### PR DESCRIPTION
If the `reinstall { enabled = true }` HCL exists for a device and the operating system, userdata, or custom data are updated; then we'll issue a reinstall action rather than a destroy / create.

Notes for @t0mk and @displague:

I think I've taken this as far as I can and I would appreciate some assistance.

## Problem 1

The 5th test-case in `_Update` seems to be wrong: `Config: testAccCheckMetalDeviceConfig_userdata(rInt+4, rs),`

This is updating the user-data and expecting the same device, which isn't the expected or actual behaviour.

Edit: Looks like a rebase removed this test-case, so I'm assuming someone already noticed it was incorrect? :)

## Problem 2

My code appears to work. The challenge is the asynchronous reinstall state; the provider tests seem to run `terraform plan` after and it can see the device is in the `reinstalling` state with the `deprovision` OS; so it thinks that there is stuff to be done. I don't know how to get aroundm this?

Edit: Resolved with @displague. Added `waitForActiveDevice()`