### PR TITLE
Add build (and vendoring) tests to pull requests

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -41,7 +41,7 @@ jobs:
           - stable
         terraform:
           - '0.12.29'
-          - '0.13.3'
+          - '0.13.6'
     steps:
 
     - name: Set up Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Go Tests
+on:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - name: Get dependencies
+      run: go mod download
+    - name: Build
+      run: go build -v .
+    - name: TF tests
+      run: go test -v -cover -parallel 4 ./metal
+

--- a/metal/resource_metal_project_ssh_key_test.go
+++ b/metal/resource_metal_project_ssh_key_test.go
@@ -2,7 +2,6 @@ package metal
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -44,7 +43,6 @@ func TestAccMetalProjectSSHKey_Basic(t *testing.T) {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
 	}
 	cfg := metalProjectSSHKeyConfig_Basic(rs, publicKeyMaterial)
-	log.Printf(cfg)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,6 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/fatih/color v1.7.0
 github.com/fatih/color


### PR DESCRIPTION
Pull requests not made by maintainers (not pushed to the equinix org) are not testing as thoroughly.  E2E acceptance tests can remain gated while we extend simpler tests to all PRs.