### PR TITLE
fix: ensure go mod vendor is up to date

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,6 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
 # github.com/davecgh/go-spew v1.1.1
-## explicit
 github.com/davecgh/go-spew/spew
 # github.com/fatih/color v1.7.0
 github.com/fatih/color


### PR DESCRIPTION
Currently the build is failing on the main branch, this should fix it.