### PR TITLE
Debug mode, Test failure annotations, Code Coverage

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -58,7 +58,7 @@ jobs:
         go mod download
 
     - name: TF acceptance tests
-      timeout-minutes: 120
+      timeout-minutes: 180
       env:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
@@ -68,10 +68,25 @@ jobs:
 
         METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test -v -cover -parallel 4 -timeout 120m ./metal
+        go test -v -json -coverprofile coverage.txt -covermode=atomic -parallel 4 -timeout 180m ./metal > test.json
+    - name: Annotate tests
+      if: always()
+      uses: guyarb/golang-test-annotations@v0.4.0
+      with:
+        test-results: test.json
     - name: Sweeper
       if: ${{ always() }}
       env:
         METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test ./metal -v -sweep="tf_test"
+        go test ./metal -v -json -sweep="tf_test"  > sweep.json
+    - name: Annotate sweep
+      if: always()
+      uses: guyarb/golang-test-annotations@v0.4.0
+      with:
+        test-results: sweep.json
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.txt

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -40,7 +40,7 @@ jobs:
         version:
           - stable
         terraform:
-          - '1.0.2'
+          - '1.0.7'
           - '0.13.6'
     steps:
 
@@ -68,24 +68,15 @@ jobs:
 
         METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test -v -json -coverprofile coverage.txt -covermode=atomic -parallel 4 -timeout 180m ./metal > test.json
-    - name: Annotate tests
-      if: always()
-      uses: guyarb/golang-test-annotations@v0.4.0
-      with:
-        test-results: test.json
+        go test -v -coverprofile coverage.txt -covermode=atomic -parallel 8 -timeout 180m ./metal
     - name: Sweeper
       if: ${{ always() }}
       env:
         METAL_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
       run: |
-        go test ./metal -v -json -sweep="tf_test"  > sweep.json
-    - name: Annotate sweep
-      if: always()
-      uses: guyarb/golang-test-annotations@v0.4.0
-      with:
-        test-results: sweep.json
+        go test ./metal -v -sweep="tf_test"
     - name: Upload coverage to Codecov
+      if: ${{ always() }}
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/main.go
+++ b/main.go
@@ -1,11 +1,28 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/equinix/terraform-provider-metal/metal"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: metal.Provider})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+	opts := &plugin.ServeOpts{ProviderFunc: metal.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/equinix/metal", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
* Adds:
  * Debug mode (https://www.terraform.io/docs/extend/debugging.html#enabling-debugging-in-a-provider)
  * ~Test failure annotations (https://github.com/marketplace/actions/golang-test-annotations) #171~
  * Code Coverage (https://app.codecov.io/gh/equinix/terraform-provider-metal)
* Increases test duration to 180m due to recent timeouts.