### PR TITLE
expose metal_port.vxlan_ids as computed attribute and alternative to vlan_ids

### DIFF
--- a/docs/data-sources/port.md
+++ b/docs/data-sources/port.md
@@ -50,4 +50,5 @@ data "metal_port" "test" {
 * `disbond_supported` - Flag indicating whether the port can be removed from a bond
 * `native_vlan_id` - UUID of native VLAN of the port
 * `vlan_ids` - UUIDs of attached VLANs
+* `vxlan_ids` - VXLAN ids of attached VLANs
 

--- a/docs/resources/port.md
+++ b/docs/resources/port.md
@@ -1,5 +1,5 @@
 ---
-page_title: "Equinix Metal: precreated_port"
+page_title: "Equinix Metal: metal_port"
 subcategory: ""
 description: |-
   Manipulate device ports
@@ -22,7 +22,8 @@ See the [Network Types Guide](../guides/network_types.md) for examples of this r
 * `port_id` - (Required) ID of the port to read
 * `bonded` - (Required) Whether the port should be bonded
 * `layer2` - (Optional) Whether to put the port to Layer 2 mode, valid only for bond ports
-* `vlan_ids` - (Optional) List off VLAN UUIDs to attach to the port
+* `vlan_ids` - (Optional) List of VLAN UUIDs to attach to the port, valid only for L2 and Hybrid ports
+* `vxlan_ids` - (Optional) List of VXLAN IDs to attach to the port, valid only for L2 and Hybrid ports
 * `native_vlan_id` - (Optional) UUID of a VLAN to assign as a native VLAN. It must be one of attached VLANs (from `vlan_ids` parameter), valid only for physical (non-bond) ports
 * `reset_on_delete` - (Optional) Behavioral setting to reset the port to default settings. For a bond port it means layer3 without vlans attached, eth ports will be bonded without native vlan and vlans attached
 
@@ -36,3 +37,6 @@ See the [Network Types Guide](../guides/network_types.md) for examples of this r
 * `bond_name` - Name of the bond port
 * `bonded` - Flag indicating whether the port is bonded
 * `disbond_supported` - Flag indicating whether the port can be removed from a bond
+* `vlan_ids` - List of VLAN UUIDs to attach to the port
+* `vxlan_ids` - List of VXLAN IDs to attach to the port
+

--- a/metal/datasource_metal_port.go
+++ b/metal/datasource_metal_port.go
@@ -74,6 +74,12 @@ func dataSourceMetalPort() *schema.Resource {
 				Description: "UUIDs of attached VLANs",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"vxlan_ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "UUIDs of attached VLANs",
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
 			"layer2": {
 				Type:        schema.TypeBool,
 				Computed:    true,

--- a/metal/port_helpers.go
+++ b/metal/port_helpers.go
@@ -112,10 +112,17 @@ func attachedVlanIds(p *packngo.Port) []string {
 }
 
 func specifiedVlanIds(d *schema.ResourceData) []string {
+	// either vlan_ids or vxlan_ids should be set, TF should ensure that
 	vlanIdsRaw, vlanIdsOk := d.GetOk("vlan_ids")
 	specified := []string{}
 	if vlanIdsOk {
 		specified = convertStringArr(vlanIdsRaw.(*schema.Set).List())
+	}
+
+	vxlanIdsRaw, vxlanIdsOk := d.GetOk("vxlan_ids")
+	specified := []string{}
+	if vxlanIdsOk {
+		specified = convertIntArr(vlanIdsRaw.(*schema.Set).List())
 	}
 	return specified
 }

--- a/metal/port_helpers.go
+++ b/metal/port_helpers.go
@@ -114,17 +114,15 @@ func attachedVlanIds(p *packngo.Port) []string {
 func specifiedVlanIds(d *schema.ResourceData) []string {
 	// either vlan_ids or vxlan_ids should be set, TF should ensure that
 	vlanIdsRaw, vlanIdsOk := d.GetOk("vlan_ids")
-	specified := []string{}
 	if vlanIdsOk {
-		specified = convertStringArr(vlanIdsRaw.(*schema.Set).List())
+		return convertStringArr(vlanIdsRaw.(*schema.Set).List())
 	}
 
 	vxlanIdsRaw, vxlanIdsOk := d.GetOk("vxlan_ids")
-	specified := []string{}
 	if vxlanIdsOk {
-		specified = convertIntArr(vlanIdsRaw.(*schema.Set).List())
+		return convertIntArr(vxlanIdsRaw.(*schema.Set).List())
 	}
-	return specified
+	return []string{}
 }
 
 func processVlansOnPort(port *packngo.Port, vlanIds []string, f portVlanAction) (*packngo.Port, error) {

--- a/metal/utils.go
+++ b/metal/utils.go
@@ -1,6 +1,9 @@
 package metal
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 func contains(s []string, e string) bool {
 	for _, a := range s {

--- a/metal/utils.go
+++ b/metal/utils.go
@@ -22,6 +22,17 @@ func convertStringArr(ifaceArr []interface{}) []string {
 	return arr
 }
 
+func convertIntArr(ifaceArr []interface{}) []string {
+	var arr []string
+	for _, v := range ifaceArr {
+		if v == nil {
+			continue
+		}
+		arr = append(arr, strconv.Itoa(v.(int)))
+	}
+	return arr
+}
+
 func toLower(v interface{}) string {
 	return strings.ToLower(v.(string))
 }


### PR DESCRIPTION
I'm using this branch to identify shortcomings of the metal_port as discovered in real integration work.

Some of the changes proposed here may be unnecessary.

* add metal_port.vxlan_ids
   It may be helpful to refer to vxlan_ids because the user can know these in advance (they are user-configurable). These ids can be sent to userdata to get OS networking configured properly.  Depending on the UUID makes need for more boilerplate. 
   I was converting a vlan_attachment resource to metal_port and accidentally used the vxlan_id field.  
   `metal_port.vlan_ids` initially accepted the "1000" value, but on a refresh, Terraform wanted to reset this to the UUID.
   ```
   Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # module.backend.metal_port.port[0] has been changed
  ~ resource "metal_port" "port" {
        id                = "d95fe575-c7f1-4d07-98f3-a3fa2c604481"
        name              = "bond0"
      ~ vlan_ids          = [
          - "1000",
          - "1001",
          + "2fb1a61d-70b8-47c1-b7bd-81a7d99b8460",
          + "84dbfaea-53ef-4476-9ed7-8ac97e6a2be0",
        ]
        # (6 unchanged attributes hidden)
    }
   ```

    Will it be problematic to have a computed vlan_ids and vxlan_ids? Does this prevent new settings from taking effect or does this prevent unwanted VLANs from being detected and detached by Terraform?