### PR TITLE
Add desired_features attribute to facility datasource

### DIFF
--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -46,7 +46,7 @@ data "metal_facility" "test" {
 The following arguments are supported:
 
 * `code` - The facility code
-* `desired_features` - Set of feature strings that the facility must have
+* `features_required` - Set of feature strings that the facility must have
 
 Facilities can be looked up by `code`.
 

--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -46,6 +46,7 @@ data "metal_facility" "test" {
 The following arguments are supported:
 
 * `code` - The facility code
+* `desired_features` - Set of feature strings that the facility must have
 
 Facilities can be looked up by `code`.
 

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -51,7 +51,7 @@ func dataSourceMetalFacility() *schema.Resource {
 				Description: "The code of the Facility to match",
 				Required:    true,
 			},
-			"desired_features": {
+			"features_required": {
 				Type:        schema.TypeSet,
 				Description: "Features which the facility needs to have.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -108,7 +108,7 @@ func dataSourceMetalFacilityRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error listing Facilities: %s", err)
 	}
 
-	dfRaw, dfOk := d.GetOk("desired_features")
+	dfRaw, dfOk := d.GetOk("features_required")
 
 	for _, f := range facilities {
 		if f.Code == code {

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -51,6 +51,13 @@ func dataSourceMetalFacility() *schema.Resource {
 				Description: "The code of the Facility to match",
 				Required:    true,
 			},
+			"desired_features": {
+				Type:        schema.TypeSet,
+				Description: "Features which the facility needs to have.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				MinItems:    1,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The name of this Facility.",
@@ -101,8 +108,16 @@ func dataSourceMetalFacilityRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error listing Facilities: %s", err)
 	}
 
+	dfRaw, dfOk := d.GetOk("desired_features")
+
 	for _, f := range facilities {
 		if f.Code == code {
+			if dfOk {
+				unsupported := difference(convertStringArr(dfRaw.(*schema.Set).List()), f.Features)
+				if len(unsupported) > 0 {
+					return fmt.Errorf("facililty %s doesn't have feature(s) %v", f.Code, unsupported)
+				}
+			}
 			d.SetId(f.ID)
 			return setMap(d, map[string]interface{}{
 				"code":     f.Code,

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -63,7 +63,7 @@ func testAccDataSourceFacilityConfigFeatures() string {
 	return `
 data "metal_facility" "test" {
     code = "ewr1"
-    desired_features = ["ibx"]
+    features_required = ["baremetal", "ibx"]
 }
 `
 }

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -8,8 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+var (
+	matchErrMissingFeature = regexp.MustCompile(`.*doesn't have feature.*`)
+	matchErrNoCapacity     = regexp.MustCompile(`Not enough capacity.*`)
+)
+
 func TestAccDataSourceFacility_Basic(t *testing.T) {
 	testFac := "dc13"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -38,6 +44,28 @@ func TestAccDataSourceFacility_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccDataSourceFacility_Features(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceFacilityConfigFeatures(),
+				ExpectError: matchErrMissingFeature,
+			},
+		},
+	})
+}
+
+func testAccDataSourceFacilityConfigFeatures() string {
+	return `
+data "metal_facility" "test" {
+    code = "ewr1"
+    desired_features = ["ibx"]
+}
+`
 }
 
 func testAccDataSourceFacilityConfigBasic(facCode string) string {
@@ -91,5 +119,3 @@ data "metal_facility" "test" {
 }
 `, facCode)
 }
-
-var matchErrNoCapacity = regexp.MustCompile(`Not enough capacity.*`)


### PR DESCRIPTION
This PR adds `desired_features` attribute to facility datasource, so that users can ensure that selected facility has certain capabilities.

Fixes #88 

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>