### PR TITLE
Capacity check for facility and metro datasources

### DIFF
--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -15,12 +15,30 @@ Provides an Equinix Metal facility datasource.
 # Fetch a facility by code and show its ID
 
 data "metal_facility" "ny5" {
-    code = "ny5"
+  code = "ny5"
 }
 
 output "id" {
   value = data.metal_facility.ny5.id
 }
+```
+
+```hcl
+# Verify that facility "dc13" has capacity for provisioning 2 c3.small.x86 
+  devices and 1 c3.medium.x86 device
+
+data "metal_facility" "test" {
+  code = "dc13"
+  capacity {
+    plan = "c3.small.x86"
+    quantity = 2
+  }
+  capacity {
+    plan = "c3.medium.x86"
+    quantity = 1
+  }
+}
+
 ```
 
 ## Argument Reference
@@ -39,3 +57,7 @@ The following attributes are exported:
 * `name` - The name of the facility
 * `features` - The features of the facility
 * `metro` - The metro code the facility is part of
+* `capacity` - Ensure that queried facility has capacity for specified number of given plans
+  - `plan` - device plan to check
+  - `quantity` - number of device to check
+

--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -57,7 +57,7 @@ The following attributes are exported:
 * `name` - The name of the facility
 * `features` - The features of the facility
 * `metro` - The metro code the facility is part of
-* `capacity` - Ensure that queried facility has capacity for specified number of given plans
+* `capacity` - (Optional) Ensure that queried facility has capacity for specified number of given plans
   - `plan` - device plan to check
   - `quantity` - number of device to check
 

--- a/docs/data-sources/metro.md
+++ b/docs/data-sources/metro.md
@@ -15,13 +15,32 @@ Provides an Equinix Metal metro datasource.
 # Fetch a metro by code and show its ID
 
 data "metal_metro" "sv" {
-    code = "sv"
+  code = "sv"
 }
 
 output "id" {
   value = data.metal_metro.sv.id
 }
 ```
+
+
+```hcl
+# Verify that metro "sv" has capacity for provisioning 2 c3.small.x86 
+  devices and 1 c3.medium.x86 device
+
+data "metal_facility" "test" {
+  code = "dc13"
+  capacity {
+    plan = "c3.small.x86"
+    quantity = 2
+  }
+  capacity {
+    plan = "c3.medium.x86"
+    quantity = 1
+  }
+}
+
+  ```
 
 ## Argument Reference
 
@@ -39,3 +58,6 @@ The following attributes are exported:
 * `code` - The code of the metro
 * `country` - The country of the metro
 * `name` - The name of the metro
+* `capacity` - (Optional) Ensure that queried metro has capacity for specified number of given plans
+  - `plan` - device plan to check
+  - `quantity` - number of device to check

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -1,59 +1,95 @@
 package metal
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccFacilityDataSource_Basic(t *testing.T) {
+func TestAccDataSourceFacility_Basic(t *testing.T) {
+	testFac := "dc13"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalFacilityDataSourceConfigBasic(),
+				Config: testAccDataSourceFacilityConfigBasic(testFac),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.metal_facility.test", "code", "ewr1"),
+						"data.metal_facility.test", "code", testFac),
 				),
 			},
-		},
-	})
-}
-
-func testAccCheckMetalFacilityDataSourceConfigBasic() string {
-	return `
-data "metal_facility" "test" {
-    code = "ewr1"
-}
-`
-}
-
-func testAccDataSourceFacilityConfigCapacity() string {
-	return `
-data "metal_facility" "test" {
-    code = "ewr1"
-    capacity {
-        plan = "t1.small.x86"
-        quantity = 1000
-    }
-}
-`
-}
-
-var matchErrNoCapacity = regexp.MustCompile(`Not enough capacity.*`)
-
-func TestAccDataSourceFacility_Capacity(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testAccDataSourceFacilityConfigCapacity(),
+				Config: testAccDataSourceFacilityConfigCapacityReasonable(testFac),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.metal_facility.test", "code", testFac),
+				),
+			},
+			{
+				Config:      testAccDataSourceFacilityConfigCapacityUnreasonable(testFac),
+				ExpectError: matchErrNoCapacity,
+			},
+			{
+				Config:      testAccDataSourceFacilityConfigCapacityUnreasonableMultiple(testFac),
 				ExpectError: matchErrNoCapacity,
 			},
 		},
 	})
 }
+
+func testAccDataSourceFacilityConfigBasic(facCode string) string {
+	return fmt.Sprintf(`
+data "metal_facility" "test" {
+    code = "%s"
+}
+`, facCode)
+}
+
+func testAccDataSourceFacilityConfigCapacityUnreasonable(facCode string) string {
+	return fmt.Sprintf(`
+data "metal_facility" "test" {
+    code = "%s"
+    capacity {
+        plan = "c3.small.x86"
+        quantity = 1000
+    }
+}
+`, facCode)
+}
+
+func testAccDataSourceFacilityConfigCapacityReasonable(facCode string) string {
+	return fmt.Sprintf(`
+data "metal_facility" "test" {
+    code = "%s"
+    capacity {
+        plan = "c3.small.x86"
+        quantity = 1
+    }
+    capacity {
+        plan = "c3.medium.x86"
+        quantity = 1
+    }
+}
+`, facCode)
+}
+
+func testAccDataSourceFacilityConfigCapacityUnreasonableMultiple(facCode string) string {
+	return fmt.Sprintf(`
+data "metal_facility" "test" {
+    code = "%s"
+    capacity {
+        plan = "c3.small.x86"
+        quantity = 1
+    }
+    capacity {
+        plan = "c3.medium.x86"
+        quantity = 1000
+    }
+}
+`, facCode)
+}
+
+var matchErrNoCapacity = regexp.MustCompile(`Not enough capacity.*`)

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -1,6 +1,7 @@
 package metal
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -28,4 +29,31 @@ data "metal_facility" "test" {
     code = "ewr1"
 }
 `
+}
+
+func testAccDataSourceFacilityConfigCapacity() string {
+	return `
+data "metal_facility" "test" {
+    code = "ewr1"
+    capacity {
+        plan = "t1.small.x86"
+        quantity = 1000
+    }
+}
+`
+}
+
+var matchErrNoCapacity = regexp.MustCompile(`Not enough capacity.*`)
+
+func TestAccDataSourceFacility_Capacity(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDataSourceFacilityConfigCapacity(),
+				ExpectError: matchErrNoCapacity,
+			},
+		},
+	})
 }


### PR DESCRIPTION
This PR adds capacity field to facility datasource in order to verify that a particular facility has enough capacity. See usage in the test.

_Originally https://github.com/equinix/terraform-provider-metal/issues/88#issuecomment-892999121_

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>