### PR TITLE
Add termination_time attr for better sweeping of test devices

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -135,33 +135,27 @@ EOS
 
 The following arguments are supported:
 
-* `hostname` - (Required) The device name
-* `project_id` - (Required) The ID of the project in which to create the device
-* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://metal.equinix.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
-* `facilities` - List of facility codes with deployment preferences. Equinix Metal API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response. Conflicts with `metro`.
-* `metro` - Metro area for the new device. Conflicts with `facilities`.
-* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://metal.equinix.com/developers/api/plans), set your auth token in the top of the page and see JSON from the API response.
+* `always_pxe` - (Optional) If true, a device with OS `custom_ipxe` will continue to boot via iPXE on reboots.
 * `billing_cycle` - (Required) monthly or hourly
-* `user_data` - (Optional) A string of the desired User Data for the device.
 * `custom_data` - (Optional) A string of the desired Custom Data for the device.
-* `ipxe_script_url` - (Optional) URL pointing to a hosted iPXE script. More
-  information is in the
-  [Custom iPXE](https://metal.equinix.com/developers/docs/servers/custom-ipxe/)
-  doc.
-* `always_pxe` - (Optional) If true, a device with OS `custom_ipxe` will
-  continue to boot via iPXE on reboots.
-* `hardware_reservation_id` - (Optional) The UUID of the hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically.
- Changing this from a reservation UUID to `next-available` will re-create the device in another reservation.
-  Please be careful when using hardware reservation UUID and `next-available` together for the same pool of reservations. It might happen that the reservation which Equinix Metal API will pick as `next-available` is the reservation which you refer with UUID in another metal_device resource. If that happens, and the metal_device with the UUID is created later, resource creation will fail because the reservation is already in use (by the resource created with `next-available`). To workaround this, have the `next-available` resource  [explicitly depend_on](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies) the resource with hardware reservation UUID, so that the latter is created first. For more details, see [issue #176](https://github.com/packethost/terraform-provider-packet/issues/176).
-* `storage` - (Optional) JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/) doc.
-  * Please note that the disks.partitions.size attribute must be a string, not an integer. It can be a number string, or size notation string, e.g. "4G" or "8M" (for gigabytes and megabytes).
-* `tags` - Tags attached to the device
 * `description` - Description string for the device
-* `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [metal_project_ssh_key](project_ssh_key.md) resource.
-* `ip_address` - (Optional) A list of IP address types for the device (structure is documented below).
-* `wait_for_reservation_deprovision` - (Optional) Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
+* `facilities` - List of facility codes with deployment preferences. Equinix Metal API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response. Conflicts with `metro`.
 * `force_detach_volumes` - (Optional) Delete device even if it has volumes attached. Only applies for destroy action.
+* `hardware_reservation_id` - (Optional) The UUID of the hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically. Changing this from a reservation UUID to `next-available` will re-create the device in another reservation. Please be careful when using hardware reservation UUID and `next-available` together for the same pool of reservations. It might happen that the reservation which Equinix Metal API will pick as `next-available` is the reservation which you refer with UUID in another metal_device resource. If that happens, and the metal_device with the UUID is created later, resource creation will fail because the reservation is already in use (by the resource created with `next-available`). To workaround this, have the `next-available` resource  [explicitly depend_on](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies) the resource with hardware reservation UUID, so that the latter is created first. For more details, see [issue #176](https://github.com/packethost/terraform-provider-packet/issues/176).
+* `hostname` - (Required) The device name
+* `ip_address` - (Optional) A list of IP address types for the device (structure is documented below).
+* `ipxe_script_url` - (Optional) URL pointing to a hosted iPXE script. More information is in the [Custom iPXE](https://metal.equinix.com/developers/docs/servers/custom-ipxe/) doc.
+* `metro` - Metro area for the new device. Conflicts with `facilities`.
+* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://metal.equinix.com/developers/api/operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
+* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://metal.equinix.com/developers/api/plans), set your auth token in the top of the page and see JSON from the API response.
+* `project_id` - (Required) The ID of the project in which to create the device
+* `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [metal_project_ssh_key](project_ssh_key.md) resource.
 * `reinstall` - (Optional) Whether the device should be reinstalled instead of destroyed when modifying user_data, custom_data, or operating system.
+* `storage` - (Optional) JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/) doc. Please note that the disks.partitions.size attribute must be a string, not an integer. It can be a number string, or size notation string, e.g. "4G" or "8M" (for gigabytes and megabytes).
+* `tags` - Tags attached to the device
+* `termination_time` - Timestamp for device termination. For example `2021-09-03T16:32:00+03:00`. If you don't supply timezone info, timestamp is assumed to be in UTC.
+* `user_data` - (Optional) A string of the desired User Data for the device.
+* `wait_for_reservation_deprovision` - (Optional) Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 
 The `ip_address` block has 3 fields:
 
@@ -178,7 +172,7 @@ The `reinstall` block has 3 fields:
 * `enabled` - Whether the provider should favour reinstall over destroy and create. Defaults to `false`.
 * `preserve_data` - (Optional) Whether the non-OS disks should be kept or wiped during reinstall. Defaults to `false`.
 * `deprovision_fast` - (Optional) Whether the OS disk should be filled with `00h` bytes before reinstall. Defaults to `false`.
-* 
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/metal/provider_test.go
+++ b/metal/provider_test.go
@@ -3,6 +3,7 @@ package metal
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -39,4 +40,8 @@ func testAccPreCheck(t *testing.T) {
 	if v == "" {
 		t.Fatal("METAL_AUTH_TOKEN must be set for acceptance tests")
 	}
+}
+
+func testDeviceTerminationTime() string {
+	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
 }

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -355,10 +355,9 @@ func resourceMetalDevice() *schema.Resource {
 			},
 			"termination_time": {
 				Type:        schema.TypeString,
-				Description: "Timestamp for device termination, use with care. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC.",
+				Description: "Timestamp for device termination. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC.",
 				Optional:    true,
 				ForceNew:    false,
-				Deprecated:  "You probably don't want to use this attribute, we added it for sweeping test artifacts.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					_, err := time.ParseInLocation(time.RFC3339, val.(string), time.UTC)
 					if err != nil {

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -628,7 +628,7 @@ func resourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	if _, ok := d.GetOk(fdv); !ok {
 		d.Set(fdv, nil)
 
-		ttv := "termination_time"
+		tt := "termination_time"
 		if _, ok := d.GetOk(tt); !ok {
 			d.Set(tt, nil)
 		}

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -353,6 +353,21 @@ func resourceMetalDevice() *schema.Resource {
 				Default:     false,
 				ForceNew:    false,
 			},
+			"termination_time": {
+				Type:        schema.TypeString,
+				Description: "Timestamp for device termination, use with care. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC.",
+				Optional:    true,
+				ForceNew:    false,
+				Deprecated:  "You probably don't want to use this attribute, we added it for sweeping test artifacts.",
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					_, err := time.ParseInLocation(time.RFC3339, val.(string), time.UTC)
+					if err != nil {
+						errs = []error{err}
+					}
+					return
+				},
+			},
+
 			"reinstall": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -459,6 +474,14 @@ func resourceMetalDeviceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if attr, ok := d.GetOk("ipxe_script_url"); ok {
 		createRequest.IPXEScriptURL = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("termination_time"); ok {
+		tt, err := time.ParseInLocation(time.RFC3339, attr.(string), time.UTC)
+		if err != nil {
+			return err
+		}
+		createRequest.TerminationTime = &packngo.Timestamp{Time: tt}
 	}
 
 	if attr, ok := d.GetOk("hardware_reservation_id"); ok {
@@ -604,6 +627,11 @@ func resourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	fdv := "force_detach_volumes"
 	if _, ok := d.GetOk(fdv); !ok {
 		d.Set(fdv, nil)
+
+		ttv := "termination_time"
+		if _, ok := d.GetOk(tt); !ok {
+			d.Set(tt, nil)
+		}
 	}
 
 	d.Set("tags", device.Tags)


### PR DESCRIPTION
This PR adds `termination_time` attirbute to metal_device". We can use it to make sure devices self-destruct in acceptance tests.

It should probably not be used by normal users as terraform apply run will attempt to create a tracked device after it self-destructed.

towards #178

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>