### PR TITLE
Optionalize metal_device hostname and billing_cycle

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -136,13 +136,13 @@ EOS
 The following arguments are supported:
 
 * `always_pxe` - (Optional) If true, a device with OS `custom_ipxe` will continue to boot via iPXE on reboots.
-* `billing_cycle` - (Required) monthly or hourly
+* `billing_cycle` - (Optional) monthly or hourly
 * `custom_data` - (Optional) A string of the desired Custom Data for the device.
-* `description` - Description string for the device
+* `description` - (Optional) The device description.
 * `facilities` - List of facility codes with deployment preferences. Equinix Metal API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://metal.equinix.com/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response. Conflicts with `metro`.
 * `force_detach_volumes` - (Optional) Delete device even if it has volumes attached. Only applies for destroy action.
 * `hardware_reservation_id` - (Optional) The UUID of the hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically. Changing this from a reservation UUID to `next-available` will re-create the device in another reservation. Please be careful when using hardware reservation UUID and `next-available` together for the same pool of reservations. It might happen that the reservation which Equinix Metal API will pick as `next-available` is the reservation which you refer with UUID in another metal_device resource. If that happens, and the metal_device with the UUID is created later, resource creation will fail because the reservation is already in use (by the resource created with `next-available`). To workaround this, have the `next-available` resource  [explicitly depend_on](https://learn.hashicorp.com/terraform/getting-started/dependencies.html#implicit-and-explicit-dependencies) the resource with hardware reservation UUID, so that the latter is created first. For more details, see [issue #176](https://github.com/packethost/terraform-provider-packet/issues/176).
-* `hostname` - (Required) The device name
+* `hostname` - (Optional) The device hostname used in deployments taking advantage of Layer3 DHCP or metadata service configuration.
 * `ip_address` - (Optional) A list of IP address types for the device (structure is documented below).
 * `ipxe_script_url` - (Optional) URL pointing to a hosted iPXE script. More information is in the [Custom iPXE](https://metal.equinix.com/developers/docs/servers/custom-ipxe/) doc.
 * `metro` - Metro area for the new device. Conflicts with `facilities`.

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -50,8 +50,9 @@ func resourceMetalDevice() *schema.Resource {
 
 			"hostname": {
 				Type:        schema.TypeString,
-				Description: "The device name",
-				Required:    true,
+				Description: "The device hostname used in deployments taking advantage of Layer3 DHCP or metadata service configuration.",
+				Optional:    true,
+				Computed:    true,
 			},
 
 			"description": {
@@ -131,7 +132,8 @@ func resourceMetalDevice() *schema.Resource {
 			"billing_cycle": {
 				Type:        schema.TypeString,
 				Description: "monthly or hourly",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 			},
 			"state": {
@@ -555,14 +557,6 @@ func resourceMetalDeviceCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	/*
-			    Possibly wait for device network state
-		    	_, err := waitForDeviceAttribute(d, []string{"layer3"}, []string{"hybrid", "layer2-bonded", "layer2-individual"}, "network_type", meta)
-		        if err != nil {
-					return err
-				}
-	*/
-
 	return resourceMetalDeviceRead(d, meta)
 }
 
@@ -608,7 +602,7 @@ func resourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 		storageString, err := structure.NormalizeJsonString(string(rawStorageBytes))
 		if err != nil {
-			return fmt.Errorf("[ERR] Errori normalizing storage JSON string for device (%s): %s", d.Id(), err)
+			return fmt.Errorf("[ERR] Error normalizing storage JSON string for device (%s): %s", d.Id(), err)
 		}
 		d.Set("storage", storageString)
 	}

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -117,11 +117,14 @@ func TestAccMetalDevice_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDeviceConfig_basic(rs),
+				Config: testAccCheckMetalDeviceConfig_minimal(rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalDeviceExists(r, &device),
 					testAccCheckMetalDeviceNetwork(r),
-					testAccCheckMetalDeviceAttributes(&device),
+					resource.TestCheckResourceAttrSet(
+						r, "hostname"),
+					resource.TestCheckResourceAttr(
+						r, "billing_cycle", "hourly"),
 					resource.TestCheckResourceAttr(
 						r, "network_type", "layer3"),
 					resource.TestCheckResourceAttr(
@@ -132,6 +135,14 @@ func TestAccMetalDevice_Basic(t *testing.T) {
 						r, "root_password"),
 					resource.TestCheckResourceAttrPair(
 						r, "deployed_facility", r, "facilities.0"),
+				),
+			},
+			{
+				Config: testAccCheckMetalDeviceConfig_basic(rs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMetalDeviceExists(r, &device),
+					testAccCheckMetalDeviceNetwork(r),
+					testAccCheckMetalDeviceAttributes(&device),
 				),
 			},
 		},
@@ -553,6 +564,20 @@ resource "metal_device" "test" {
   metro            = "sv"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
+  project_id       = "${metal_project.test.id}"
+}`, projSuffix)
+}
+
+func testAccCheckMetalDeviceConfig_minimal(projSuffix string) string {
+	return fmt.Sprintf(`
+resource "metal_project" "test" {
+    name = "tfacc-device-%s"
+}
+
+resource "metal_device" "test" {
+  plan             = "t1.small.x86"
+  facilities       = ["sjc1"]
+  operating_system = "ubuntu_16_04"
   project_id       = "${metal_project.test.id}"
 }`, projSuffix)
 }


### PR DESCRIPTION
Makes metal_device hostname and billing_cycle optional and computed when not provided.

This allows hosts to report the default Equinix Metal API generated-hostnames.
This also simplifies the boiler-plate needed to provision devices.

Requires #186 