### PR TITLE
bump packngo to 0.19.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/packethost/packngo v0.19.0
+	github.com/packethost/packngo v0.19.1
 )
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.19.0 h1:uve9pPODyIEXxJWSurn59hmHt7fHdAxRof0XjwBHRiU=
-github.com/packethost/packngo v0.19.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.19.1 h1:zuZasgaV4qHMeQ+djENj21w8vhgpoZO2h1a09buVjD8=
+github.com/packethost/packngo v0.19.1/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/github.com/packethost/packngo/devices.go
+++ b/vendor/github.com/packethost/packngo/devices.go
@@ -380,14 +380,14 @@ type CPR struct {
 
 // DeviceCreateRequest type used to create an Equinix Metal device
 type DeviceCreateRequest struct {
-	Hostname              string     `json:"hostname"`
+	Hostname              string     `json:"hostname,omitempty"`
 	Plan                  string     `json:"plan"`
 	Facility              []string   `json:"facility,omitempty"`
 	Metro                 string     `json:"metro,omitempty"`
 	OS                    string     `json:"operating_system"`
-	BillingCycle          string     `json:"billing_cycle"`
+	BillingCycle          string     `json:"billing_cycle,omitempty"`
 	ProjectID             string     `json:"project_id"`
-	UserData              string     `json:"userdata"`
+	UserData              string     `json:"userdata,omitempty"`
 	Storage               *CPR       `json:"storage,omitempty"`
 	Tags                  []string   `json:"tags"`
 	Description           string     `json:"description,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -185,7 +185,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/packethost/packngo v0.19.0
+# github.com/packethost/packngo v0.19.1
 ## explicit
 github.com/packethost/packngo
 # github.com/ulikunitz/xz v0.5.8


### PR DESCRIPTION
This PR bumps packngo to 0.19.1 where hostname, userdata and billing cycle are optional

towards #185 

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>