### PR TITLE
fix Virtual Circuit disconnecting before delete

### DIFF
--- a/metal/resource_metal_virtual_circuit.go
+++ b/metal/resource_metal_virtual_circuit.go
@@ -249,9 +249,10 @@ func resourceMetalVirtualCircuitUpdate(d *schema.ResourceData, meta interface{})
 func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 	// we first need to disconnect VLAN from the VC
+	empty := ""
 	_, _, err := client.VirtualCircuits.Update(
 		d.Id(),
-		&packngo.VCUpdateRequest{VirtualNetworkID: nil},
+		&packngo.VCUpdateRequest{VirtualNetworkID: &empty},
 		nil,
 	)
 	if err != nil {


### PR DESCRIPTION
_I suspect this..._
Fixes #183 

`Error: PUT https://api.equinix.com/metal/v1/virtual-circuits/31e13e9e-57e8-4720-a9b2-a715106a9a8c: 422 Update params can't be blank`

https://github.com/packethost/packngo/blob/86fc114a1bf21d9f0ad2f16ddbbecd769b79ee4a/virtualcircuits.go#L40 
The `omitempty` here will prevent the `nil` `VirtualNetworkID` from being sent to the API. By using an empty string, the API will receive something, however it is not clear to me if the API will accept `""` to declare the intention to disconnect the VLAN, or if we will need to change packngo to permit `null` to be sent.  In this case, we could use an option that may be undefined/omitted or literal null or string:
```
VirtualNetworkID **string `json:"vnid,omitempty"`, 
```

