### PR TITLE
termination_time to acceptance tests

### DIFF
--- a/metal/datasource_metal_device_test.go
+++ b/metal/datasource_metal_device_test.go
@@ -50,12 +50,13 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
+  termination_time = "%s"
 }
 
 data "metal_device" "test" {
   project_id       = metal_project.test.id
   hostname         = metal_device.test.hostname
-}`, projSuffix)
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func TestAccDataSourceMetalDevice_ByID(t *testing.T) {
@@ -100,9 +101,10 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
+  termination_time = "%s"
 }
 
 data "metal_device" "test" {
   device_id       = metal_device.test.id
-}`, projSuffix)
+}`, projSuffix, testDeviceTerminationTime())
 }

--- a/metal/datasource_metal_ip_block_ranges_test.go
+++ b/metal/datasource_metal_ip_block_ranges_test.go
@@ -49,6 +49,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 data "metal_ip_block_ranges" "test" {
@@ -60,5 +61,5 @@ resource "metal_ip_attachment" "test" {
     device_id = metal_device.test.id
     cidr_notation = cidrsubnet(data.metal_ip_block_ranges.test.ipv6.0, 8,2)
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/metal/datasource_metal_port_test.go
+++ b/metal/datasource_metal_port_test.go
@@ -41,6 +41,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 data "metal_port" "test" {
@@ -48,7 +49,7 @@ data "metal_port" "test" {
     name      = "eth0"
 }
 
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func TestAccMetalPort_ById(t *testing.T) {
@@ -84,11 +85,12 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 data "metal_port" "test" {
   port_id        = metal_device.test.ports[0].id
 }
 
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/metal/datasource_metal_precreated_ip_block_test.go
+++ b/metal/datasource_metal_precreated_ip_block_test.go
@@ -49,6 +49,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 data "metal_precreated_ip_block" "test" {
@@ -62,5 +63,5 @@ resource "metal_ip_attachment" "test" {
     device_id = metal_device.test.id
     cidr_notation = cidrsubnet(data.metal_precreated_ip_block.test.cidr_notation,8,2)
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/metal/resource_metal_bgp_setup_test.go
+++ b/metal/resource_metal_bgp_setup_test.go
@@ -82,6 +82,7 @@ resource "metal_device" "test" {
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${metal_project.test.id}"
+    termination_time = "%s"
 }
 
 resource "metal_bgp_session" "test4" {
@@ -99,5 +100,5 @@ resource "metal_bgp_session" "test6" {
 data "metal_device_bgp_neighbors" "test" {
   device_id  = metal_bgp_session.test4.device_id
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -627,10 +627,10 @@ func resourceMetalDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	if _, ok := d.GetOk(fdv); !ok {
 		d.Set(fdv, nil)
 
-		tt := "termination_time"
-		if _, ok := d.GetOk(tt); !ok {
-			d.Set(tt, nil)
-		}
+	}
+	tt := "termination_time"
+	if _, ok := d.GetOk(tt); !ok {
+		d.Set(tt, nil)
 	}
 
 	d.Set("tags", device.Tags)

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -473,8 +473,9 @@ resource "metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
   tags             = ["%d"]
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt)
+`, projSuffix, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
@@ -492,13 +493,14 @@ resource "metal_device" "test" {
   project_id       = "${metal_project.test.id}"
   tags             = ["%d"]
   user_data = "#!/usr/bin/env sh\necho Reinstall\n"
+  termination_time = "%s"
 
   reinstall {
 	  enabled = true
 	  deprovision_fast = true
   }
 }
-`, projSuffix, rInt, rInt)
+`, projSuffix, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_varname(rInt int, projSuffix string) string {
@@ -516,8 +518,9 @@ resource "metal_device" "test" {
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
   tags             = ["%d"]
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt, rInt)
+`, projSuffix, rInt, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_varname_pxe(rInt int, projSuffix string) string {
@@ -537,8 +540,9 @@ resource "metal_device" "test" {
   tags             = ["%d"]
   always_pxe       = true
   ipxe_script_url  = "http://matchbox.foo.wtf:8080/boot.ipxe"
+  termination_time = "%s"
 }
-`, projSuffix, rInt, rInt, rInt)
+`, projSuffix, rInt, rInt, rInt, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_metro(projSuffix string) string {
@@ -554,7 +558,8 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_basic(projSuffix string) string {
@@ -570,7 +575,8 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_facility_list(projSuffix string) string {
@@ -587,7 +593,8 @@ resource "metal_device" "test"  {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
-}`, projSuffix)
+  termination_time = "%s"
+}`, projSuffix, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
@@ -607,7 +614,8 @@ resource "metal_device" "test_ipxe_script_url"  {
   project_id       = "${metal_project.test.id}"
   ipxe_script_url  = "%s"
   always_pxe       = "%s"
-}`, projSuffix, url, pxe)
+  termination_time = "%s"
+}`, projSuffix, url, pxe, testDeviceTerminationTime())
 }
 
 var testAccCheckMetalDeviceConfig_ipxe_conflict = `

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -448,7 +448,7 @@ func TestAccMetalDevice_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDeviceConfig_basic(rs),
+				Config: testAccCheckMetalDeviceConfig_importBasic(rs),
 			},
 			{
 				ResourceName:      "metal_device.test",
@@ -577,6 +577,22 @@ resource "metal_device" "test" {
   project_id       = "${metal_project.test.id}"
   termination_time = "%s"
 }`, projSuffix, testDeviceTerminationTime())
+}
+
+func testAccCheckMetalDeviceConfig_importBasic(projSuffix string) string {
+	return fmt.Sprintf(`
+resource "metal_project" "test" {
+    name = "tfacc-device-%s"
+}
+
+resource "metal_device" "test" {
+  hostname         = "tfacc-test-device"
+  plan             = "t1.small.x86"
+  facilities       = ["sjc1"]
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${metal_project.test.id}"
+}`, projSuffix)
 }
 
 func testAccCheckMetalDeviceConfig_facility_list(projSuffix string) string {

--- a/metal/resource_metal_ip_attachment_test.go
+++ b/metal/resource_metal_ip_attachment_test.go
@@ -66,6 +66,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 resource "metal_reserved_ip_block" "test" {
@@ -78,7 +79,7 @@ resource "metal_reserved_ip_block" "test" {
 resource "metal_ip_attachment" "test" {
 	device_id = metal_device.test.id
 	cidr_notation = "${cidrhost(metal_reserved_ip_block.test.cidr_notation,0)}/32"
-}`, name)
+}`, name, testDeviceTerminationTime())
 }
 
 func TestAccMetalIPAttachment_Metro(t *testing.T) {
@@ -122,6 +123,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
+  termination_time = "%s"
 }
 
 resource "metal_reserved_ip_block" "test" {
@@ -134,5 +136,5 @@ resource "metal_reserved_ip_block" "test" {
 resource "metal_ip_attachment" "test" {
 	device_id = metal_device.test.id
 	cidr_notation = "${cidrhost(metal_reserved_ip_block.test.cidr_notation,0)}/32"
-}`, name)
+}`, name, testDeviceTerminationTime())
 }

--- a/metal/resource_metal_port_test.go
+++ b/metal/resource_metal_port_test.go
@@ -23,6 +23,7 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
+  termination_time = "%s"
 }
 
 locals {
@@ -31,7 +32,7 @@ locals {
   eth0_id = [for p in metal_device.test.ports: p.id if p.name == "eth0"][0]
 }
 
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func confAccMetalPort_L3(name string) string {

--- a/metal/resource_metal_port_vlan_attachment_test.go
+++ b/metal/resource_metal_port_vlan_attachment_test.go
@@ -25,8 +25,9 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalPortVlanAttachmentConfig_L2Bonded_2(name string) string {
@@ -110,8 +111,9 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalPortVlanAttachmentConfig_L2Individual_2(name string) string {
@@ -197,7 +199,8 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalPortVlanAttachmentConfig_Hybrid_2(name string) string {
@@ -267,7 +270,8 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalPortVlanAttachmentConfig_HybridMultipleVlans_2(name string) string {
@@ -381,7 +385,8 @@ resource "metal_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
-}`, name)
+  termination_time = "%s"
+}`, name, testDeviceTerminationTime())
 }
 
 func testAccCheckMetalPortVlanAttachmentConfig_L2Native_2(name string) string {

--- a/metal/resource_metal_project_ssh_key_test.go
+++ b/metal/resource_metal_project_ssh_key_test.go
@@ -30,9 +30,10 @@ resource "metal_device" "test" {
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${metal_project_ssh_key.test.id}"]
     project_id          = "${metal_project.test.id}"
+    termination_time    = "%s"
 }
 
-`, name, publicSshKey)
+`, name, publicSshKey, testDeviceTerminationTime())
 }
 
 func TestAccMetalProjectSSHKey_Basic(t *testing.T) {

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -242,8 +242,9 @@ resource "metal_device" "test" {
   ip_address {
 	 type = "private_ipv4"
   }
+  termination_time = "%s"
 }
-`, name)
+`, name, testDeviceTerminationTime())
 }
 
 func TestAccMetalReservedIPBlock_Device(t *testing.T) {


### PR DESCRIPTION
This PR adds termination_time to all the relevant metal_device resources in provider acceptance tests. Fixes equinix/terraform-provider-equinix#166 

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>