### PR TITLE
Add `end_at` param to spot_market_request to allow limiting SMR duration

### DIFF
--- a/docs/resources/spot_market_request.md
+++ b/docs/resources/spot_market_request.md
@@ -39,6 +39,7 @@ The following arguments are supported:
 * `max_bid_price` - (Required) Maximum price user is willing to pay per hour per device
 * `project_id` - (Required) Project ID
 * `wait_for_devices` - (Optional) On resource creation - wait until all desired devices are active, on resource destruction - wait until devices are removed
+* `end_at` - (Optional) Deadline for the request. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC."
 * `facilities` - (Optional) Facility IDs where devices should be created
 * `metro` - (Optional) Metro where devices should be created
 * `locked` - (Optional) Blocks deletion of the SpotMarketRequest device until the lock is disabled
@@ -47,7 +48,6 @@ The following arguments are supported:
   * `plan`
   * `operating_system`
   * `hostname`
-  * `termintation_time`
   * `always_pxe`
   * `description`
   * `features`

--- a/metal/provider_test.go
+++ b/metal/provider_test.go
@@ -45,3 +45,7 @@ func testAccPreCheck(t *testing.T) {
 func testDeviceTerminationTime() string {
 	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
 }
+
+func testSpotMarketRequestTerminationTime() string {
+	return time.Now().UTC().Add(60 * time.Minute).Format(time.RFC3339)
+}

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -74,6 +74,25 @@ func resourceMetalSpotMarketRequest() *schema.Resource {
 				ConflictsWith: []string{"facilities"},
 				StateFunc:     toLower,
 			},
+			"end_at": {
+				Type:        schema.TypeString,
+				Description: "Deadline for the request. For example \"2021-09-03T16:32:00+03:00\". If you don't supply timezone info, timestamp is assumed to be in UTC.",
+				Optional:    true,
+				ForceNew:    true,
+
+				StateFunc: func(v interface{}) string {
+					t, _ := time.Parse(time.RFC3339, v.(string))
+					// remove fraction of second
+					return t.Truncate(time.Second * 1).Format(time.RFC3339)
+				},
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					_, err := time.ParseInLocation(time.RFC3339, val.(string), time.UTC)
+					if err != nil {
+						errs = []error{err}
+					}
+					return
+				},
+			},
 			"instance_parameters": {
 				Type:        schema.TypeList,
 				Description: "Parameters for devices provisioned from this request. You can find the parameter description from the [metal_device doc](device.md)",
@@ -284,6 +303,14 @@ func resourceMetalSpotMarketRequestCreate(d *schema.ResourceData, meta interface
 		Parameters:  params,
 	}
 
+	if attr, ok := d.GetOk("end_at"); ok {
+		eaTime, err := time.ParseInLocation(time.RFC3339, attr.(string), time.UTC)
+		if err != nil {
+			return err
+		}
+		smrc.EndAt = &packngo.Timestamp{Time: eaTime}
+	}
+
 	smr, _, err := client.SpotMarketRequests.Create(smrc, d.Get("project_id").(string))
 	if err != nil {
 		return err
@@ -330,7 +357,7 @@ func resourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface{}
 		metro = smr.Metro.Code
 	}
 
-	return setMap(d, map[string]interface{}{
+	attrMap := map[string]interface{}{
 		"metro":         metro,
 		"project_id":    smr.Project.ID,
 		"devices_min":   smr.DevicesMin,
@@ -347,7 +374,13 @@ func resourceMetalSpotMarketRequestRead(d *schema.ResourceData, meta interface{}
 			}
 			return d.Set(k, facilityCodes)
 		},
-	})
+	}
+
+	if smr.EndAt != nil {
+		attrMap["endAt"] = smr.EndAt.Format(time.RFC3339)
+	}
+
+	return setMap(d, attrMap)
 }
 
 func resourceMetalSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -32,6 +32,7 @@ resource "metal_spot_market_request" "request" {
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
+  end_at = "%s"
 
   instance_parameters {
     hostname         = "tfacc-testspot"
@@ -39,7 +40,7 @@ resource "metal_spot_market_request" "request" {
     operating_system = "ubuntu_18_04"
     plan             = "c3.small.x86"
   }
-}`, name)
+}`, name, testSpotMarketRequestTerminationTime())
 }
 
 func TestAccMetalSpotMarketRequest_Basic(t *testing.T) {
@@ -124,6 +125,7 @@ resource "metal_spot_market_request" "request" {
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
+  end_at           = "%s"
 
   instance_parameters {
     hostname         = "tfacc-testspot"
@@ -131,7 +133,7 @@ resource "metal_spot_market_request" "request" {
     operating_system = "ubuntu_20_04"
     plan             = "c3.small.x86"
   }
-}`, name)
+}`, name, testSpotMarketRequestTerminationTime())
 }
 
 func TestAccMetalSpotMarketRequest_Import(t *testing.T) {


### PR DESCRIPTION
This PR adds `end_at` parameter to metal_spot_market_request to allow removing the SMR in future. Will be useful for our acceptance tests.

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>