### PR TITLE
Fix ErrorResponse interface to satisfy TF SDK

### DIFF
--- a/metal/errors.go
+++ b/metal/errors.go
@@ -1,6 +1,7 @@
 package metal
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -14,6 +15,7 @@ import (
 // friendlyError improves error messages when the API error is blank or in an
 // alternate format (as is the case with invalid token or loadbalancer errors)
 func friendlyError(err error) error {
+
 	if e, ok := err.(*packngo.ErrorResponse); ok {
 		resp := e.Response
 		errors := Errors(e.Errors)
@@ -71,6 +73,18 @@ type ErrorResponse struct {
 	StatusCode int
 	Errors
 	IsAPIError bool
+}
+
+func (er ErrorResponse) Error() string {
+	ret := ""
+	if er.IsAPIError {
+		ret += "API Error "
+	}
+	if er.StatusCode != 0 {
+		ret += fmt.Sprintf("HTTP %d ", er.StatusCode)
+	}
+	ret += er.Errors.Error()
+	return ret
 }
 
 // setMap sets the map of values to ResourceData, checking and returning the

--- a/metal/errors.go
+++ b/metal/errors.go
@@ -75,7 +75,7 @@ type ErrorResponse struct {
 	IsAPIError bool
 }
 
-func (er ErrorResponse) Error() string {
+func (er *ErrorResponse) Error() string {
 	ret := ""
 	if er.IsAPIError {
 		ret += "API Error "


### PR DESCRIPTION
This PR fixes the situation where the EM API returns HTTP 422, and `errors: []` in the body. Like this:

```
---[ REQUEST ]---------------------------------------
DELETE /metal/v1/projects/0a286170-17fc-43a0-9b68-4ddfb41c4f4c HTTP/1.1
Host: api.equinix.com
User-Agent: HashiCorp Terraform/0.11+compatible (+https://www.terraform.io) Terraform Plugin SDK/2.7.0 terraform-provider-metal/dev packngo/v0.19.1
Connection: close
Accept: application/json
Content-Type: application/json
X-Consumer-Token: aZ9GmqHTPtxevvFq9SK3Pi2yr9YCbRzduCSXF2SNem5sjB91mDq7Th3ZwTtRqMWZ
Accept-Encoding: gzip


-----------------------------------------------------: timestamp=2021-10-18T18:19:22.374+0300
2021-10-18T18:19:23.206+0300 [INFO]  provider.terraform-provider-metal: 2021/10/18 18:19:23 [DEBUG] Equinix Metal API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 422 Unprocessable Entity
Connection: close
Content-Length: 13
Cache-Control: no-cache
Content-Type: application/json; charset=utf-8
Date: Mon, 18 Oct 2021 15:19:23 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
X-Request-Id: 6e1b741e5249ce3f03812ebad8fd1770

{
 "errors": []
}
```

Hopefully fixes #195 