### PR TITLE
Fix for error when deleting device with hardware_reservation_id == next-available

### DIFF
--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -778,7 +778,7 @@ func resourceMetalDeviceDelete(d *schema.ResourceData, meta interface{}) error {
 		return friendlyError(err)
 	}
 
-	resId, resIdOk := d.GetOk("hardware_reservation_id")
+	resId, resIdOk := d.GetOk("deployed_hardware_reservation_id")
 	if resIdOk {
 		wfrd, wfrdOK := d.GetOk("wait_for_reservation_deprovision")
 		if wfrdOK && wfrd.(bool) {


### PR DESCRIPTION
This PR fixes device deletion when provider waits for deprovision of hw reservation AND the hardware_reservation_id was specified as `next-available`.

fixes #199 

Signed-off-by: Tomas Karasek <tom.to.the.k@gmail.com>