### PR TITLE
Fabric service tokens in metal_connection

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -23,19 +23,26 @@ data "metal_connection" "example" {
 
 ## Attributes Reference
 
-* `description` - Description of the connection resource
 * `name` - Name of the connection resource
-* `tags` - String list of tags
-* `facility` - Slug of a facility to which the connection belongs
 * `metro` - Slug of a metro to which the connection belongs
-* `organization_id` - ID of organization to which the connection belongs
-* `project_id` - ID of project to which the connection belongs
-* `status` - Status of the connection
-* `token` - Fabric Token for the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)
-* `type` - Connection type, dedicated or shared
-* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel
+* `facility` - Slug of a facility to which the connection belongs
 * `redundancy` - Connection redundancy, reduntant or primary
-* `speed` - Connection speed in bits per second
+* `type` - Connection type, dedicated or shared
+* `project_id` - ID of project to which the connection belongs
+* `speed` - Connection speed, one of 50Mbps, 200Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps
+* `description` - Description of the connection resource
+* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel
+* `tags` - String list of tags
+* `vlans` - Attached VLANs. Only available in shared connection. One vlan for Primary/Single connection and two vlans for Redundant connection
+* `service_token_type` - Type of service token, a_side or z_side. One available in shared connection.
+* `organization_id` - ID of the organization where the connection is scoped to
+* `status` - Status of the connection resource
+* `service_tokens` - List of connection service tokens with attributes
+  * `id` - UUID of the service token
+  * `expires_at` - Expiration date of the service token
+  * `max_allowed_speed` - Maximum allowed speed for the service token, string like in the `speed` attribute
+  * `type` - Token type, `a_side` or `z_side`
+  * `role` - Token role, `primary` or `secondary`
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)
   * `name` - Port name
   * `id` - Port UUID
@@ -44,3 +51,4 @@ data "metal_connection" "example" {
   * `status` - Port status 
   * `link_status` - Port link status
   * `virtual_circuit_ids` - List of IDs of virtual cicruits attached to this port
+* `token` - (Deprecated) Fabric Token from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -12,34 +12,43 @@ Use this resource to request of create an Interconnection from [Equinix Fabric -
 ## Example Usage
 
 ```hcl
+
 resource "metal_connection" "test" {
-    name            = "My Interconnection"
-    organization_id = local.my_organization_id
-    project_id      = local.my_project_id
-    metro           = "sv"
-    redundancy      = "redundant"
-    type            = "shared"
+	name               = "My Interconnection"
+	project_id         = metal_project.test.id
+	type               = "shared"
+	redundancy         = "redundant"
+	metro              = "sv"
+	speed              = "50Mbps"
+	service_token_type = "a_side"
 }
 ```
 
 ## Argument Reference
 
 * `name` - (Required) Name of the connection resource
-* `organization_id` - (Required) ID of the organization responsible for the connection
-* `redundancy` - (Required) Connection redundancy - redundant or primary
-* `type` - (Required) Connection type - dedicated or shared
-* `mode` - Mode for connections in IBX facilities with the dedicated type - standard or tunnel
-* `project_id` - (Optional) ID of the project where the connection is scoped to, must be set for shared connection
 * `metro` - (Optional) Metro where the connection will be created
 * `facility` - (Optional) Facility where the connection will be created
+* `redundancy` - (Required) Connection redundancy - redundant or primary
+* `type` - (Required) Connection type - dedicated or shared
+* `project_id` - (Required) ID of the project where the connection is scoped to, must be set for shared connection
+* `speed` - (Required) Connection speed - one of 50Mbps, 200Mbps, 500Mbps, 1Gbps, 2Gbps, 5Gbps, 10Gbps
 * `description` - (Optional) Description for the connection resource
+* `mode` - (Optional) Mode for connections in IBX facilities with the dedicated type - standard or tunnel. Default is standard
 * `tags` - (Optional) String list of tags
+* `vlans` - (Optional) Only used with shared connection. Vlans to attach. Pass one vlan for Primary/Single connection and two vlans for Redundant connection
+* `service_token_type` - (Optional) Only used with shared connection. Type of service token to use for the connection, a_side or z_side
 
 ## Attributes Reference
 
+* `organization_id` - ID of the organization where the connection is scoped to
 * `status` - Status of the connection resource
-* `token` - Fabric Token from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)
-* `speed` - Port speed in bits per second
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`). Schema of port is described in documentation of the [metal_connection datasource](../data-sources/connection.md).
-
+* `service_tokens` - List of connection service tokens with attributes
+  * `id` - UUID of the service token
+  * `expires_at` - Expiration date of the service token
+  * `max_allowed_speed` - Maximum allowed speed for the service token, string like in the `speed` attribute
+  * `type` - Token type, `a_side` or `z_side`
+  * `role` - Token role, `primary` or `secondary`
+* `token` - (Deprecated) Fabric Token from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -44,11 +44,4 @@ resource "metal_connection" "test" {
 * `organization_id` - ID of the organization where the connection is scoped to
 * `status` - Status of the connection resource
 * `ports` - List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`). Schema of port is described in documentation of the [metal_connection datasource](../data-sources/connection.md).
-* `service_tokens` - List of connection service tokens with attributes
-  * `id` - UUID of the service token
-  * `expires_at` - Expiration date of the service token
-  * `max_allowed_speed` - Maximum allowed speed for the service token, string like in the `speed` attribute
-  * `type` - Token type, `a_side` or `z_side`
-  * `role` - Token role, `primary` or `secondary`
-* `token` - (Deprecated) Fabric Token from the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)
-
+* `service_tokens` - List of connection service tokens with attributes. Scehma of service_token is described in documentation of the [metal_connection datasource](../data-sources/connection.md).

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.19.1
+	github.com/packethost/packngo v0.19.2-0.20210922152159-b073e9ef6568
 )
 
 go 1.16
+
+replace github.com/packethost/packngo => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.19.2-0.20210922152159-b073e9ef6568
+	github.com/packethost/packngo v0.20.1-0.20220109151846-46c24be88530
 )
 
 go 1.16
-
-replace github.com/packethost/packngo => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.19.1 h1:zuZasgaV4qHMeQ+djENj21w8vhgpoZO2h1a09buVjD8=
-github.com/packethost/packngo v0.19.1/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -296,6 +294,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/t0mk/packngo v0.0.0-20211229100455-60e67ce94ba6 h1:2alykI8Cl2vENPAXu1nQ/WEgeLQVyPSTZfG2UGWa5KQ=
+github.com/t0mk/packngo v0.0.0-20211229100455-60e67ce94ba6/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/t0mk/packngo v0.0.0-20211231072250-69eb30014ada h1:raahQHEIs3FRyIWAwNwFeHJzaebBT2Uzrx3GxKke7yc=
+github.com/t0mk/packngo v0.0.0-20211231072250-69eb30014ada/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc h1:2aUdLdsicAbahzZd+Bnh4rWJf1dNI36SHUr2NzeuYA8=
+github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/packethost/packngo v0.20.1-0.20220109151846-46c24be88530 h1:uH4MsehdsLGfFUR+I6Sf+Wg8B1zE+g1lTHzPpYyE8RQ=
+github.com/packethost/packngo v0.20.1-0.20220109151846-46c24be88530/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -294,12 +296,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/t0mk/packngo v0.0.0-20211229100455-60e67ce94ba6 h1:2alykI8Cl2vENPAXu1nQ/WEgeLQVyPSTZfG2UGWa5KQ=
-github.com/t0mk/packngo v0.0.0-20211229100455-60e67ce94ba6/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
-github.com/t0mk/packngo v0.0.0-20211231072250-69eb30014ada h1:raahQHEIs3FRyIWAwNwFeHJzaebBT2Uzrx3GxKke7yc=
-github.com/t0mk/packngo v0.0.0-20211231072250-69eb30014ada/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
-github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc h1:2aUdLdsicAbahzZd+Bnh4rWJf1dNI36SHUr2NzeuYA8=
-github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/metal/datasource_metal_connection.go
+++ b/metal/datasource_metal_connection.go
@@ -1,9 +1,49 @@
 package metal
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/packethost/packngo"
 )
+
+func serviceTokenSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "ID of the service token",
+				Computed:    true,
+			},
+			"expires_at": {
+				Type:        schema.TypeString,
+				Description: "Expiration date of the service token",
+				Computed:    true,
+			},
+			"max_allowed_speed": {
+				Type:        schema.TypeString,
+				Description: "Maximum allowed speed for the service token",
+				Computed:    true,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Description: "Type of the service token, a_side or z_side",
+				Computed:    true,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Description: "State of the service token",
+				Computed:    true,
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Description: "Role of the service token",
+				Computed:    true,
+			},
+		},
+	}
+}
 
 func connectionPortSchema() *schema.Resource {
 	return &schema.Resource{
@@ -49,6 +89,10 @@ func connectionPortSchema() *schema.Resource {
 }
 
 func dataSourceMetalConnection() *schema.Resource {
+	speeds := []string{}
+	for _, allowedSpeed := range allowedSpeeds {
+		speeds = append(speeds, allowedSpeed.Str)
+	}
 	return &schema.Resource{
 		Read: dataSourceMetalConnectionRead,
 
@@ -63,10 +107,45 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Description: "Name of the connection resource",
 			},
+			"facility": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Facility which the connection is scoped to",
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Metro which the connection is scoped to",
+			},
+			"redundancy": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection redundancy - redundant or primary",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection type - dedicated or shared",
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of project to which the connection belongs",
+			},
+			"speed": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: fmt.Sprintf("Port speed. Possible values are %s", strings.Join(speeds, ", ")),
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of the connection resource",
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Connection mode - standard or tunnel",
 			},
 			"tags": {
 				Type:        schema.TypeList,
@@ -74,61 +153,43 @@ func dataSourceMetalConnection() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"vlans": {
+				Type:        schema.TypeList,
+				Description: "Attached vlans, only in shared connection.",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+			},
+			"service_token_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Only used with shared connection. Type of service token to use for the connection, a_side or z_side.",
+			},
 			"organization_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "ID of organization to which the connection belongs",
-			},
-			"project_id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "ID of project to which the connection belongs",
+				Description: "ID of organization to which the connection is scoped to",
 			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Status of the connection resource",
 			},
-			"redundancy": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Connection redundancy - reduntant or primary",
-			},
-			"facility": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Slug of a facility to which the connection belongs",
-			},
-			"metro": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Slug of a metro to which the connection belongs",
-			},
 			"token": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Fabric Token for the [Equinix Fabric Portal](https://ecxfabric.equinix.com/dashboard)",
-			},
-			"type": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Connection type - dedicated or shared",
-			},
-			"mode": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Mode for connections in IBX facilities with the dedicated type - standard or tunnel",
-			},
-			"speed": {
-				Type:        schema.TypeInt,
-				Computed:    true,
-				Description: "Port speed in bits per second",
 			},
 			"ports": {
 				Type:        schema.TypeList,
 				Elem:        connectionPortSchema(),
 				Computed:    true,
 				Description: "List of connection ports - primary (`ports[0]`) and secondary (`ports[1]`)",
+			},
+			"service_tokens": {
+				Type:        schema.TypeList,
+				Description: "Only used with shared connection. List of service tokens to use for the connection.",
+				Computed:    true,
+				Elem:        serviceTokenSchema(),
 			},
 		},
 	}
@@ -160,4 +221,24 @@ func dataSourceMetalConnectionRead(d *schema.ResourceData, meta interface{}) err
 	connId := d.Get("connection_id").(string)
 	d.SetId(connId)
 	return resourceMetalConnectionRead(d, meta)
+}
+
+func getServiceTokens(tokens []packngo.FabricServiceToken) ([]map[string]interface{}, error) {
+	tokenList := []map[string]interface{}{}
+	for _, token := range tokens {
+		speed, err := speedUintToStr(token.MaxAllowedSpeed)
+		if err != nil {
+			return nil, err
+		}
+		rawToken := map[string]interface{}{
+			"id":                token.ID,
+			"expires_at":        token.ExpiresAt.String(),
+			"max_allowed_speed": speed,
+			"role":              string(token.Role),
+			"state":             token.State,
+			"type":              string(token.ServiceTokenType),
+		}
+		tokenList = append(tokenList, rawToken)
+	}
+	return tokenList, nil
 }

--- a/metal/resource_metal_connection.go
+++ b/metal/resource_metal_connection.go
@@ -80,7 +80,7 @@ func resourceMetalConnection() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				Description:   "Metro where to the connection will be created",
+				Description:   "Metro where the connection will be created",
 				ConflictsWith: []string{"facility"},
 				ForceNew:      true,
 				StateFunc:     toLower,
@@ -173,63 +173,10 @@ func resourceMetalConnection() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Only used with shared connection. List of service tokens to use for the connection.",
 				Computed:    true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:        schema.TypeString,
-							Description: "ID of the service token",
-							Computed:    true,
-						},
-						"expires_at": {
-							Type:        schema.TypeString,
-							Description: "Expiration date of the service token",
-							Computed:    true,
-						},
-						"max_allowed_speed": {
-							Type:        schema.TypeString,
-							Description: "Maximum allowed speed for the service token",
-							Computed:    true,
-						},
-						"type": {
-							Type:        schema.TypeString,
-							Description: "Type of the service token, a_side or z_side",
-							Computed:    true,
-						},
-						"state": {
-							Type:        schema.TypeString,
-							Description: "State of the service token",
-							Computed:    true,
-						},
-						"role": {
-							Type:        schema.TypeString,
-							Description: "Role of the service token",
-							Computed:    true,
-						},
-					},
-				},
+				Elem:        serviceTokenSchema(),
 			},
 		},
 	}
-}
-
-func getServiceTokens(tokens []packngo.FabricServiceToken) ([]map[string]interface{}, error) {
-	tokenList := []map[string]interface{}{}
-	for _, token := range tokens {
-		speed, err := speedUintToStr(token.MaxAllowedSpeed)
-		if err != nil {
-			return nil, err
-		}
-		rawToken := map[string]interface{}{
-			"id":                token.ID,
-			"expires_at":        token.ExpiresAt.String(),
-			"max_allowed_speed": speed,
-			"role":              string(token.Role),
-			"state":             token.State,
-			"type":              string(token.ServiceTokenType),
-		}
-		tokenList = append(tokenList, rawToken)
-	}
-	return tokenList, nil
 }
 
 func resourceMetalConnectionCreate(d *schema.ResourceData, meta interface{}) error {

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/packethost/packngo"
 )
 
+func TestSpeedConversion(t *testing.T) {
+	speedUint, err := speedStrToUint("50Mbps")
+	if err != nil {
+		t.Errorf("Error converting speed string to uint: %s", err)
+
+	}
+	if speedUint != 50*mega {
+		t.Errorf("Speed string conversion failed. Expected: %d, got: %d", 50*mega, speedUint)
+	}
+
+	speedStr, err := speedUintToStr(50 * mega)
+	if err != nil {
+		t.Errorf("Error converting speed uint to string: %s", err)
+	}
+	if speedStr != "50Mbps" {
+		t.Errorf("Speed uint conversion failed. Expected: %s, got: %s", "50Mbps", speedStr)
+	}
+
+	speedUint, err = speedStrToUint("100Gbps")
+	if err == nil {
+		t.Errorf("Expected error converting invalid speed string to uint, got: %d", speedUint)
+	}
+
+	speedStr, err = speedUintToStr(100 * giga)
+	if err == nil {
+		t.Errorf("Expected error converting invalid speed uint to string, got: %s", speedStr)
+	}
+}
+
 func testAccCheckMetalConnectionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*packngo.Client)
 

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -99,6 +99,21 @@ func TestAccMetalConnection_Shared(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccMetalConnectionConfig_Shared(rs) + testDataSourceMetalConnectionConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.metal_connection.test", "metro", "sv"),
+					resource.TestCheckResourceAttr("data.metal_connection.test", "mode", "standard"),
+					resource.TestCheckResourceAttr("data.metal_connection.test", "type", "shared"),
+					resource.TestCheckResourceAttr("data.metal_connection.test", "redundancy", "redundant"),
+					resource.TestCheckResourceAttr(
+						"data.metal_connection.test", "service_tokens.0.type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"data.metal_connection.test", "service_token_type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"data.metal_connection.test", "service_tokens.0.max_allowed_speed", "50Mbps"),
+				),
+			},
 		},
 	})
 }
@@ -123,7 +138,7 @@ func testAccMetalConnectionConfig_Dedicated(randstr string) string {
 		randstr, randstr)
 }
 
-func testDataSourceMetalConnectionConfig_Dedicated() string {
+func testDataSourceMetalConnectionConfig() string {
 	return `
 		data "metal_connection" "test" {
             connection_id = metal_connection.test.id
@@ -155,7 +170,7 @@ func TestAccMetalConnection_Dedicated(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMetalConnectionConfig_Dedicated(rs) + testDataSourceMetalConnectionConfig_Dedicated(),
+				Config: testAccMetalConnectionConfig_Dedicated(rs) + testDataSourceMetalConnectionConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.metal_connection.test", "metro", "sv"),
 					resource.TestCheckResourceAttr("data.metal_connection.test", "tags.#", "1"),

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -61,12 +61,13 @@ func testAccMetalConnectionConfig_Shared(randstr string) string {
         }
 
         resource "metal_connection" "test" {
-            name            = "tfacc-conn-%s"
-            organization_id = metal_project.test.organization_id
-            project_id      = metal_project.test.id
-            metro           = "sv"
-            redundancy      = "redundant"
-            type            = "shared"
+            name               = "tfacc-conn-%s"
+            project_id         = metal_project.test.id
+            type               = "shared"
+            redundancy         = "redundant"
+            metro              = "sv"
+			speed              = "50Mbps"
+			service_token_type = "a_side"
         }`,
 		randstr, randstr)
 }
@@ -85,6 +86,12 @@ func TestAccMetalConnection_Shared(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"metal_connection.test", "metro", "sv"),
+					resource.TestCheckResourceAttr(
+						"metal_connection.test", "service_tokens.0.type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"metal_connection.test", "service_token_type", "a_side"),
+					resource.TestCheckResourceAttr(
+						"metal_connection.test", "service_tokens.0.max_allowed_speed", "50Mbps"),
 				),
 			},
 			{
@@ -105,11 +112,12 @@ func testAccMetalConnectionConfig_Dedicated(randstr string) string {
         // No project ID. We only use the project resource to get org_id
         resource "metal_connection" "test" {
             name            = "tfacc-conn-%s"
-            organization_id = metal_project.test.organization_id
             metro           = "sv"
-            redundancy      = "redundant"
+            project_id      = metal_project.test.id
             type            = "dedicated"
+            redundancy      = "redundant"
 			tags            = ["tfacc"]
+			speed           = "50Mbps"
 			mode            = "standard"
         }`,
 		randstr, randstr)
@@ -139,7 +147,6 @@ func TestAccMetalConnection_Dedicated(t *testing.T) {
 					resource.TestCheckResourceAttr("metal_connection.test", "mode", "standard"),
 					resource.TestCheckResourceAttr("metal_connection.test", "type", "dedicated"),
 					resource.TestCheckResourceAttr("metal_connection.test", "redundancy", "redundant"),
-					resource.TestCheckResourceAttr("metal_connection.test", "metro", "sv"),
 				),
 			},
 			{
@@ -155,7 +162,6 @@ func TestAccMetalConnection_Dedicated(t *testing.T) {
 					resource.TestCheckResourceAttr("data.metal_connection.test", "mode", "standard"),
 					resource.TestCheckResourceAttr("data.metal_connection.test", "type", "dedicated"),
 					resource.TestCheckResourceAttr("data.metal_connection.test", "redundancy", "redundant"),
-					resource.TestCheckResourceAttr("data.metal_connection.test", "metro", "sv"),
 				),
 			},
 		},

--- a/metal/utils.go
+++ b/metal/utils.go
@@ -36,6 +36,17 @@ func convertIntArr(ifaceArr []interface{}) []string {
 	return arr
 }
 
+func convertIntArr2(ifaceArr []interface{}) []int {
+	var arr []int
+	for _, v := range ifaceArr {
+		if v == nil {
+			continue
+		}
+		arr = append(arr, v.(int))
+	}
+	return arr
+}
+
 func toLower(v interface{}) string {
 	return strings.ToLower(v.(string))
 }

--- a/vendor/github.com/packethost/packngo/README.md
+++ b/vendor/github.com/packethost/packngo/README.md
@@ -17,10 +17,12 @@ To import this library into your Go project:
 import "github.com/packethost/packngo"
 ```
 
-Reference a particular version with:
+**Note:** A minimum of Go 1.14 is required for development.
+
+Download module  with:
 
 ```sh
-go get github.com/packethost/packngo@v0.2.0
+go get github.com/packethost/packngo
 ```
 
 ## Stability and Compatibility

--- a/vendor/github.com/packethost/packngo/apikeys.go
+++ b/vendor/github.com/packethost/packngo/apikeys.go
@@ -89,6 +89,9 @@ func (s *APIKeyServiceOp) list(url string, opts *ListOptions) ([]APIKey, *Respon
 // ProjectList lists the API keys associated with a project having `projectID`
 // match `Project.ID`.
 func (s *APIKeyServiceOp) ProjectList(projectID string, opts *ListOptions) ([]APIKey, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, apiKeyBasePath)
 	return s.list(endpointPath, opts)
 }
@@ -112,6 +115,12 @@ func (s *APIKeyServiceOp) UserList(opts *ListOptions) ([]APIKey, *Response, erro
 // for a match. Therefor, the Response is not returned and a custom error will
 // be returned when the key is not found.
 func (s *APIKeyServiceOp) ProjectGet(projectID, apiKeyID string, opts *GetOptions) (*APIKey, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, validateErr
+	}
+	if validateErr := ValidateUUID(apiKeyID); validateErr != nil {
+		return nil, validateErr
+	}
 	pkeys, _, err := s.ProjectList(projectID, opts)
 	if err != nil {
 		return nil, err
@@ -133,6 +142,9 @@ func (s *APIKeyServiceOp) ProjectGet(projectID, apiKeyID string, opts *GetOption
 // for a match. Therefor, the Response is not returned and a custom error will
 // be returned when the key is not found.
 func (s *APIKeyServiceOp) UserGet(apiKeyID string, opts *GetOptions) (*APIKey, error) {
+	if validateErr := ValidateUUID(apiKeyID); validateErr != nil {
+		return nil, validateErr
+	}
 	ukeys, _, err := s.UserList(opts)
 	if err != nil {
 		return nil, err
@@ -171,6 +183,9 @@ func (s *APIKeyServiceOp) Create(createRequest *APIKeyCreateRequest) (*APIKey, *
 //
 // Project API keys can not be used to delete themselves.
 func (s *APIKeyServiceOp) Delete(apiKeyID string) (*Response, error) {
+	if validateErr := ValidateUUID(apiKeyID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(userBasePath, apiKeyBasePath, apiKeyID)
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
 }

--- a/vendor/github.com/packethost/packngo/batches.go
+++ b/vendor/github.com/packethost/packngo/batches.go
@@ -55,6 +55,9 @@ type BatchServiceOp struct {
 
 // Get returns batch details
 func (s *BatchServiceOp) Get(batchID string, opts *GetOptions) (*Batch, *Response, error) {
+	if validateErr := ValidateUUID(batchID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(batchBasePath, batchID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	batch := new(Batch)
@@ -69,6 +72,9 @@ func (s *BatchServiceOp) Get(batchID string, opts *GetOptions) (*Batch, *Respons
 
 // List returns batches on a project
 func (s *BatchServiceOp) List(projectID string, opts *ListOptions) (batches []Batch, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, batchBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	subset := new(batchesList)
@@ -83,6 +89,9 @@ func (s *BatchServiceOp) List(projectID string, opts *ListOptions) (batches []Ba
 
 // Create function to create batch of device instances
 func (s *BatchServiceOp) Create(projectID string, request *BatchCreateRequest) ([]Batch, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID, "devices", "batch")
 
 	batches := new(batchesList)
@@ -97,6 +106,9 @@ func (s *BatchServiceOp) Create(projectID string, request *BatchCreateRequest) (
 
 // Delete function to remove an instance batch
 func (s *BatchServiceOp) Delete(id string, removeDevices bool) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	// API doc days the remove_associated_instances params shout be in the body
 	// https://metal.equinix.com/developers/api/batches/#delete-the-batch
 	// .. does this even work?

--- a/vendor/github.com/packethost/packngo/bgp_configs.go
+++ b/vendor/github.com/packethost/packngo/bgp_configs.go
@@ -47,6 +47,9 @@ type BGPConfig struct {
 
 // Create function
 func (s *BGPConfigServiceOp) Create(projectID string, request CreateBGPConfigRequest) (*Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID, bgpConfigPostBasePath)
 
 	resp, err := s.client.DoRequest("POST", apiPath, request, nil)
@@ -59,6 +62,9 @@ func (s *BGPConfigServiceOp) Create(projectID string, request CreateBGPConfigReq
 
 // Get function
 func (s *BGPConfigServiceOp) Get(projectID string, opts *GetOptions) (bgpConfig *BGPConfig, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, bgpConfigGetBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -74,6 +80,9 @@ func (s *BGPConfigServiceOp) Get(projectID string, opts *GetOptions) (bgpConfig 
 
 // Delete function TODO: this is not implemented in the Equinix Metal API
 // func (s *BGPConfigServiceOp) Delete(configID string) (resp *Response, err error) {
+// if validateErr := ValidateUUID(configID); validateErr != nil {
+//  return nil, validateErr
+// }
 // 	apiPath := fmt.Sprintf("%ss/%s", bgpConfigBasePath, configID)
 
 // 	resp, err = s.client.DoRequest("DELETE", apiPath, nil, nil)

--- a/vendor/github.com/packethost/packngo/bgp_sessions.go
+++ b/vendor/github.com/packethost/packngo/bgp_sessions.go
@@ -67,6 +67,9 @@ type CreateBGPSessionRequest struct {
 
 // Create function
 func (s *BGPSessionServiceOp) Create(deviceID string, request CreateBGPSessionRequest) (*BGPSession, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, bgpSessionBasePath)
 	session := new(BGPSession)
 
@@ -80,6 +83,9 @@ func (s *BGPSessionServiceOp) Create(deviceID string, request CreateBGPSessionRe
 
 // Delete function
 func (s *BGPSessionServiceOp) Delete(id string) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(bgpSessionBasePath, id)
 
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -87,6 +93,9 @@ func (s *BGPSessionServiceOp) Delete(id string) (*Response, error) {
 
 // Get function
 func (s *BGPSessionServiceOp) Get(id string, opts *GetOptions) (session *BGPSession, response *Response, err error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(bgpSessionBasePath, id)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	session = new(BGPSession)

--- a/vendor/github.com/packethost/packngo/device_ports.go
+++ b/vendor/github.com/packethost/packngo/device_ports.go
@@ -64,6 +64,9 @@ func (i *DevicePortServiceOp) AssignNative(par *PortAssignRequest) (*Port, *Resp
 //
 // Deprecated: use PortServiceOp.UnassignNative
 func (i *DevicePortServiceOp) UnassignNative(portID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	return i.client.Ports.UnassignNative(portID)
 }
 
@@ -145,6 +148,9 @@ func (i *DevicePortServiceOp) PortToLayerThree(deviceID, portName string) (*Port
 //
 // Deprecated: use Device.GetNetworkType
 func (i *DevicePortServiceOp) DeviceNetworkType(deviceID string) (string, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return "", validateErr
+	}
 	d, _, err := i.client.Devices.Get(deviceID, nil)
 	if err != nil {
 		return "", err
@@ -290,6 +296,9 @@ func (i *DevicePortServiceOp) ConvertDevice(d *Device, targetType string) error 
 // Deprecated: use DevicePortServiceOp.ConvertDevice which this function thinly
 // wraps.
 func (i *DevicePortServiceOp) DeviceToNetworkType(deviceID string, targetType string) (*Device, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	d, _, err := i.client.Devices.Get(deviceID, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/packethost/packngo/devices.go
+++ b/vendor/github.com/packethost/packngo/devices.go
@@ -49,6 +49,7 @@ type Device struct {
 	Description         *string                `json:"description,omitempty"`
 	State               string                 `json:"state,omitempty"`
 	Created             string                 `json:"created_at,omitempty"`
+	CreatedBy           *UserLite              `json:"created_by,omitempty"`
 	Updated             string                 `json:"updated_at,omitempty"`
 	Locked              bool                   `json:"locked,omitempty"`
 	BillingCycle        string                 `json:"billing_cycle,omitempty"`
@@ -186,6 +187,9 @@ func (b *BandwidthOpts) WithQuery(apiPath string) string {
 }
 
 func (d *DeviceServiceOp) GetBandwidth(deviceID string, opts *BandwidthOpts) (*BandwidthIO, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(deviceBasePath, deviceID, "bandwidth")
 	apiPathQuery := opts.WithQuery(endpointPath)
 	bw := new(bandwidthRoot)
@@ -468,6 +472,9 @@ type DeviceServiceOp struct {
 // Plan.Name, Plan.Slug, Facility.Code, Facility.Name, OS.Name, OS.Slug,
 // HardwareReservation.ID, HardwareReservation.ShortID
 func (s *DeviceServiceOp) List(projectID string, opts *ListOptions) (devices []Device, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	opts = opts.Including("facility")
 	endpointPath := path.Join(projectBasePath, projectID, deviceBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -492,6 +499,9 @@ func (s *DeviceServiceOp) List(projectID string, opts *ListOptions) (devices []D
 
 // Get returns a device by id
 func (s *DeviceServiceOp) Get(deviceID string, opts *GetOptions) (*Device, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	opts = opts.Including("facility")
 	endpointPath := path.Join(deviceBasePath, deviceID)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -517,6 +527,9 @@ func (s *DeviceServiceOp) Create(createRequest *DeviceCreateRequest) (*Device, *
 
 // Update updates an existing device
 func (s *DeviceServiceOp) Update(deviceID string, updateRequest *DeviceUpdateRequest) (*Device, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	opts := &GetOptions{}
 	opts = opts.Including("facility")
 	endpointPath := path.Join(deviceBasePath, deviceID)
@@ -533,6 +546,9 @@ func (s *DeviceServiceOp) Update(deviceID string, updateRequest *DeviceUpdateReq
 
 // Delete deletes a device
 func (s *DeviceServiceOp) Delete(deviceID string, force bool) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID)
 	req := &DeviceDeleteRequest{Force: force}
 
@@ -541,6 +557,9 @@ func (s *DeviceServiceOp) Delete(deviceID string, force bool) (*Response, error)
 
 // Reboot reboots on a device
 func (s *DeviceServiceOp) Reboot(deviceID string) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, "actions")
 	action := &DeviceActionRequest{Type: "reboot"}
 
@@ -549,6 +568,9 @@ func (s *DeviceServiceOp) Reboot(deviceID string) (*Response, error) {
 
 // Reinstall reinstalls a device
 func (s *DeviceServiceOp) Reinstall(deviceID string, fields *DeviceReinstallFields) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	path := fmt.Sprintf("%s/%s/actions", deviceBasePath, deviceID)
 	action := &DeviceReinstallRequest{DeviceActionRequest{Type: "reinstall"}, fields}
 
@@ -557,6 +579,9 @@ func (s *DeviceServiceOp) Reinstall(deviceID string, fields *DeviceReinstallFiel
 
 // PowerOff powers on a device
 func (s *DeviceServiceOp) PowerOff(deviceID string) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, "actions")
 	action := &DeviceActionRequest{Type: "power_off"}
 
@@ -565,6 +590,9 @@ func (s *DeviceServiceOp) PowerOff(deviceID string) (*Response, error) {
 
 // PowerOn powers on a device
 func (s *DeviceServiceOp) PowerOn(deviceID string) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, "actions")
 	action := &DeviceActionRequest{Type: "power_on"}
 
@@ -577,6 +605,9 @@ type lockType struct {
 
 // Lock sets a device to "locked"
 func (s *DeviceServiceOp) Lock(deviceID string) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID)
 	action := lockType{Locked: true}
 
@@ -585,6 +616,9 @@ func (s *DeviceServiceOp) Lock(deviceID string) (*Response, error) {
 
 // Unlock sets a device to "unlocked"
 func (s *DeviceServiceOp) Unlock(deviceID string) (*Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID)
 	action := lockType{Locked: false}
 
@@ -592,6 +626,9 @@ func (s *DeviceServiceOp) Unlock(deviceID string) (*Response, error) {
 }
 
 func (s *DeviceServiceOp) ListBGPNeighbors(deviceID string, opts *ListOptions) ([]BGPNeighbor, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	root := new(bgpNeighborsRoot)
 	endpointPath := path.Join(deviceBasePath, deviceID, bgpNeighborsBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -606,6 +643,9 @@ func (s *DeviceServiceOp) ListBGPNeighbors(deviceID string, opts *ListOptions) (
 
 // ListBGPSessions returns all BGP Sessions associated with the device
 func (s *DeviceServiceOp) ListBGPSessions(deviceID string, opts *ListOptions) (bgpSessions []BGPSession, resp *Response, err error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 
 	endpointPath := path.Join(deviceBasePath, deviceID, bgpSessionBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -629,6 +669,9 @@ func (s *DeviceServiceOp) ListBGPSessions(deviceID string, opts *ListOptions) (b
 
 // ListEvents returns list of device events
 func (s *DeviceServiceOp) ListEvents(deviceID string, opts *ListOptions) ([]Event, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, eventBasePath)
 
 	return listEvents(s.client, apiPath, opts)

--- a/vendor/github.com/packethost/packngo/email.go
+++ b/vendor/github.com/packethost/packngo/email.go
@@ -39,6 +39,9 @@ type EmailServiceOp struct {
 
 // Get retrieves an email by id
 func (s *EmailServiceOp) Get(emailID string, opts *GetOptions) (*Email, *Response, error) {
+	if validateErr := ValidateUUID(emailID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(emailBasePath, emailID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	email := new(Email)
@@ -65,6 +68,9 @@ func (s *EmailServiceOp) Create(request *EmailRequest) (*Email, *Response, error
 
 // Delete removes the email address from the current user account
 func (s *EmailServiceOp) Delete(emailID string) (*Response, error) {
+	if validateErr := ValidateUUID(emailID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(emailBasePath, emailID)
 
 	resp, err := s.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -77,6 +83,9 @@ func (s *EmailServiceOp) Delete(emailID string) (*Response, error) {
 
 // Update email parameters
 func (s *EmailServiceOp) Update(emailID string, request *EmailRequest) (*Email, *Response, error) {
+	if validateErr := ValidateUUID(emailID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	email := new(Email)
 	apiPath := path.Join(emailBasePath, emailID)
 

--- a/vendor/github.com/packethost/packngo/events.go
+++ b/vendor/github.com/packethost/packngo/events.go
@@ -41,6 +41,9 @@ func (s *EventServiceOp) List(listOpt *ListOptions) ([]Event, *Response, error) 
 
 // Get returns an event by ID
 func (s *EventServiceOp) Get(eventID string, getOpt *GetOptions) (*Event, *Response, error) {
+	if validateErr := ValidateUUID(eventID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(eventBasePath, eventID)
 	return get(s.client, apiPath, getOpt)
 }

--- a/vendor/github.com/packethost/packngo/fabric_service_tokens.go
+++ b/vendor/github.com/packethost/packngo/fabric_service_tokens.go
@@ -1,0 +1,42 @@
+package packngo
+
+import "path"
+
+type FabricServiceTokenType string
+
+const (
+	fabricServiceTokenBasePath                        = "/fabric-service-tokens"
+	FabricServiceTokenASide    FabricServiceTokenType = "a_side"
+	FabricServiceTokenZSide    FabricServiceTokenType = "z_side"
+)
+
+// FabricServiceToken represents an Equinix Metal metro
+type FabricServiceToken struct {
+	*Href            `json:",inline"`
+	ExpiresAt        Timestamp              `json:"expires_at,omitempty"`
+	ID               string                 `json:"id"`
+	MaxAllowedSpeed  uint64                 `json:"max_allowed_speed,omitempty"`
+	Role             ConnectionPortRole     `json:"role,omitempty"`
+	ServiceTokenType FabricServiceTokenType `json:"service_token_type,omitempty"`
+	State            string                 `json:"state,omitempty"`
+}
+
+func (f FabricServiceToken) String() string {
+	return Stringify(f)
+}
+
+// FabricServiceTokenServiceOp implements FabricServiceTokenService
+type FabricServiceTokenServiceOp struct {
+	client *Client
+}
+
+func (s *FabricServiceTokenServiceOp) Get(id string, opts *GetOptions) (*FabricServiceToken, *Response, error) {
+	endpointPath := path.Join(fabricServiceTokenBasePath, id)
+	apiPathQuery := opts.WithQuery(endpointPath)
+	fst := new(FabricServiceToken)
+	resp, err := s.client.DoRequest("GET", apiPathQuery, nil, fst)
+	if err != nil {
+		return nil, resp, err
+	}
+	return fst, resp, err
+}

--- a/vendor/github.com/packethost/packngo/hardware_reservations.go
+++ b/vendor/github.com/packethost/packngo/hardware_reservations.go
@@ -42,6 +42,9 @@ type hardwareReservationRoot struct {
 
 // List returns all hardware reservations for a given project
 func (s *HardwareReservationServiceOp) List(projectID string, opts *ListOptions) (reservations []HardwareReservation, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, hardwareReservationBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -63,6 +66,9 @@ func (s *HardwareReservationServiceOp) List(projectID string, opts *ListOptions)
 
 // Get returns a single hardware reservation
 func (s *HardwareReservationServiceOp) Get(hardwareReservationdID string, opts *GetOptions) (*HardwareReservation, *Response, error) {
+	if validateErr := ValidateUUID(hardwareReservationdID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	hardwareReservation := new(HardwareReservation)
 
 	endpointPath := path.Join(hardwareReservationBasePath, hardwareReservationdID)
@@ -78,6 +84,12 @@ func (s *HardwareReservationServiceOp) Get(hardwareReservationdID string, opts *
 
 // Move a hardware reservation to another project
 func (s *HardwareReservationServiceOp) Move(hardwareReservationdID, projectID string) (*HardwareReservation, *Response, error) {
+	if validateErr := ValidateUUID(hardwareReservationdID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	hardwareReservation := new(HardwareReservation)
 	apiPath := path.Join(hardwareReservationBasePath, hardwareReservationdID, "move")
 	body := map[string]string{}

--- a/vendor/github.com/packethost/packngo/ip.go
+++ b/vendor/github.com/packethost/packngo/ip.go
@@ -116,6 +116,9 @@ type AddressStruct struct {
 }
 
 func deleteFromIP(client *Client, resourceID string) (*Response, error) {
+	if validateErr := ValidateUUID(resourceID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(ipBasePath, resourceID)
 
 	return client.DoRequest("DELETE", apiPath, nil, nil)
@@ -138,12 +141,18 @@ type DeviceIPServiceOp struct {
 // This will remove the relationship between an IP and the device and will make the IP
 // address available to be assigned to another device.
 func (i *DeviceIPServiceOp) Unassign(assignmentID string) (*Response, error) {
+	if validateErr := ValidateUUID(assignmentID); validateErr != nil {
+		return nil, validateErr
+	}
 	return deleteFromIP(i.client, assignmentID)
 }
 
 // Assign assigns an IP address to a device.
 // The IP address must be in one of the IP ranges assigned to the device’s project.
 func (i *DeviceIPServiceOp) Assign(deviceID string, assignRequest *AddressStruct) (*IPAddressAssignment, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(deviceBasePath, deviceID, ipBasePath)
 	ipa := new(IPAddressAssignment)
 
@@ -157,6 +166,9 @@ func (i *DeviceIPServiceOp) Assign(deviceID string, assignRequest *AddressStruct
 
 // Get returns assignment by ID.
 func (i *DeviceIPServiceOp) Get(assignmentID string, opts *GetOptions) (*IPAddressAssignment, *Response, error) {
+	if validateErr := ValidateUUID(assignmentID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(ipBasePath, assignmentID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	ipa := new(IPAddressAssignment)
@@ -171,6 +183,9 @@ func (i *DeviceIPServiceOp) Get(assignmentID string, opts *GetOptions) (*IPAddre
 
 // List list all of the IP address assignments on a device
 func (i *DeviceIPServiceOp) List(deviceID string, opts *ListOptions) ([]IPAddressAssignment, *Response, error) {
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(deviceBasePath, deviceID, ipBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -196,6 +211,9 @@ type ProjectIPServiceOp struct {
 
 // Get returns reservation by ID.
 func (i *ProjectIPServiceOp) Get(reservationID string, opts *GetOptions) (*IPAddressReservation, *Response, error) {
+	if validateErr := ValidateUUID(reservationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(ipBasePath, reservationID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	ipr := new(IPAddressReservation)
@@ -210,6 +228,9 @@ func (i *ProjectIPServiceOp) Get(reservationID string, opts *GetOptions) (*IPAdd
 
 // List provides a list of IP resevations for a single project.
 func (i *ProjectIPServiceOp) List(projectID string, opts *ListOptions) ([]IPAddressReservation, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, ipBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	reservations := new(struct {
@@ -225,6 +246,9 @@ func (i *ProjectIPServiceOp) List(projectID string, opts *ListOptions) ([]IPAddr
 
 // Request requests more IP space for a project in order to have additional IP addresses to assign to devices.
 func (i *ProjectIPServiceOp) Request(projectID string, ipReservationReq *IPReservationRequest) (*IPAddressReservation, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID, ipBasePath)
 	ipr := new(IPAddressReservation)
 
@@ -237,11 +261,17 @@ func (i *ProjectIPServiceOp) Request(projectID string, ipReservationReq *IPReser
 
 // Remove removes an IP reservation from the project.
 func (i *ProjectIPServiceOp) Remove(ipReservationID string) (*Response, error) {
+	if validateErr := ValidateUUID(ipReservationID); validateErr != nil {
+		return nil, validateErr
+	}
 	return deleteFromIP(i.client, ipReservationID)
 }
 
 // AvailableAddresses lists addresses available from a reserved block
 func (i *ProjectIPServiceOp) AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error) {
+	if validateErr := ValidateUUID(ipReservationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPathQuery := fmt.Sprintf("%s/%s/available?cidr=%d", ipBasePath, ipReservationID, r.CIDR)
 	ar := new(AvailableResponse)
 

--- a/vendor/github.com/packethost/packngo/metal_gateway.go
+++ b/vendor/github.com/packethost/packngo/metal_gateway.go
@@ -36,6 +36,9 @@ type MetalGatewayServiceOp struct {
 }
 
 func (s *MetalGatewayServiceOp) List(projectID string, opts *ListOptions) (metalGateways []MetalGateway, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	type metalGatewaysRoot struct {
 		MetalGateways []MetalGateway `json:"metal_gateways"`
 		Meta          meta           `json:"meta"`
@@ -69,6 +72,9 @@ type MetalGatewayCreateRequest struct {
 }
 
 func (s *MetalGatewayServiceOp) Get(metalGatewayID string, opts *GetOptions) (*MetalGateway, *Response, error) {
+	if validateErr := ValidateUUID(metalGatewayID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(metalGatewayBasePath, metalGatewayID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	metalGateway := new(MetalGateway)
@@ -82,6 +88,9 @@ func (s *MetalGatewayServiceOp) Get(metalGatewayID string, opts *GetOptions) (*M
 }
 
 func (s *MetalGatewayServiceOp) Create(projectID string, input *MetalGatewayCreateRequest) (*MetalGateway, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID, metalGatewayBasePath)
 	output := new(MetalGateway)
 
@@ -94,6 +103,9 @@ func (s *MetalGatewayServiceOp) Create(projectID string, input *MetalGatewayCrea
 }
 
 func (s *MetalGatewayServiceOp) Delete(metalGatewayID string) (*Response, error) {
+	if validateErr := ValidateUUID(metalGatewayID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(metalGatewayBasePath, metalGatewayID)
 
 	resp, err := s.client.DoRequest("DELETE", apiPath, nil, nil)

--- a/vendor/github.com/packethost/packngo/notifications.go
+++ b/vendor/github.com/packethost/packngo/notifications.go
@@ -44,6 +44,9 @@ func (s *NotificationServiceOp) List(listOpt *ListOptions) ([]Notification, *Res
 
 // Get returns a notification by ID
 func (s *NotificationServiceOp) Get(notificationID string, opts *GetOptions) (*Notification, *Response, error) {
+	if validateErr := ValidateUUID(notificationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(notificationBasePath, notificationID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	return getNotifications(s.client, apiPathQuery)
@@ -51,6 +54,9 @@ func (s *NotificationServiceOp) Get(notificationID string, opts *GetOptions) (*N
 
 // Marks notification as read by ID
 func (s *NotificationServiceOp) MarkAsRead(notificationID string) (*Notification, *Response, error) {
+	if validateErr := ValidateUUID(notificationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(notificationBasePath, notificationID)
 	return markAsRead(s.client, apiPath)
 }

--- a/vendor/github.com/packethost/packngo/organizations.go
+++ b/vendor/github.com/packethost/packngo/organizations.go
@@ -103,6 +103,9 @@ func (s *OrganizationServiceOp) List(opts *ListOptions) (orgs []Organization, re
 
 // Get returns a organization by id
 func (s *OrganizationServiceOp) Get(organizationID string, opts *GetOptions) (*Organization, *Response, error) {
+	if validateErr := ValidateUUID(organizationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(organizationBasePath, organizationID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	organization := new(Organization)
@@ -129,6 +132,9 @@ func (s *OrganizationServiceOp) Create(createRequest *OrganizationCreateRequest)
 
 // Update updates an organization
 func (s *OrganizationServiceOp) Update(id string, updateRequest *OrganizationUpdateRequest) (*Organization, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(organizationBasePath, id)
 	organization := new(Organization)
 
@@ -142,6 +148,9 @@ func (s *OrganizationServiceOp) Update(id string, updateRequest *OrganizationUpd
 
 // Delete deletes an organizationID
 func (s *OrganizationServiceOp) Delete(organizationID string) (*Response, error) {
+	if validateErr := ValidateUUID(organizationID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(organizationBasePath, organizationID)
 
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -149,6 +158,9 @@ func (s *OrganizationServiceOp) Delete(organizationID string) (*Response, error)
 
 // ListPaymentMethods returns PaymentMethods for an organization
 func (s *OrganizationServiceOp) ListPaymentMethods(organizationID string) ([]PaymentMethod, *Response, error) {
+	if validateErr := ValidateUUID(organizationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(organizationBasePath, organizationID, paymentMethodBasePath)
 	root := new(paymentMethodsRoot)
 
@@ -162,6 +174,9 @@ func (s *OrganizationServiceOp) ListPaymentMethods(organizationID string) ([]Pay
 
 // ListEvents returns list of organization events
 func (s *OrganizationServiceOp) ListEvents(organizationID string, listOpt *ListOptions) ([]Event, *Response, error) {
+	if validateErr := ValidateUUID(organizationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(organizationBasePath, organizationID, eventBasePath)
 
 	return listEvents(s.client, apiPath, listOpt)

--- a/vendor/github.com/packethost/packngo/plans.go
+++ b/vendor/github.com/packethost/packngo/plans.go
@@ -136,10 +136,16 @@ func (s *PlanServiceOp) List(opts *ListOptions) ([]Plan, *Response, error) {
 
 // ProjectList method returns plans available in a project
 func (s *PlanServiceOp) ProjectList(projectID string, opts *ListOptions) ([]Plan, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	return planList(s.client, path.Join(projectBasePath, projectID, planBasePath), opts)
 }
 
 // OrganizationList method returns plans available in an organization
 func (s *PlanServiceOp) OrganizationList(organizationID string, opts *ListOptions) ([]Plan, *Response, error) {
+	if validateErr := ValidateUUID(organizationID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	return planList(s.client, path.Join(organizationBasePath, organizationID, planBasePath), opts)
 }

--- a/vendor/github.com/packethost/packngo/ports.go
+++ b/vendor/github.com/packethost/packngo/ports.go
@@ -106,6 +106,12 @@ type DisbondRequest struct {
 
 // Assign adds a VLAN to a port
 func (i *PortServiceOp) Assign(portID, vlanID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(vlanID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "assign")
 	par := &PortAssignRequest{VirtualNetworkID: vlanID}
 
@@ -114,6 +120,12 @@ func (i *PortServiceOp) Assign(portID, vlanID string) (*Port, *Response, error) 
 
 // AssignNative assigns a virtual network to the port as a "native VLAN"
 func (i *PortServiceOp) AssignNative(portID, vlanID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(vlanID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "native-vlan")
 	par := &PortAssignRequest{VirtualNetworkID: vlanID}
 	return i.portAction(apiPath, par)
@@ -121,6 +133,9 @@ func (i *PortServiceOp) AssignNative(portID, vlanID string) (*Port, *Response, e
 
 // UnassignNative removes native VLAN from the supplied port
 func (i *PortServiceOp) UnassignNative(portID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "native-vlan")
 	port := new(Port)
 
@@ -134,6 +149,12 @@ func (i *PortServiceOp) UnassignNative(portID string) (*Port, *Response, error) 
 
 // Unassign removes a VLAN from the port
 func (i *PortServiceOp) Unassign(portID, vlanID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(vlanID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "unassign")
 	par := &PortAssignRequest{VirtualNetworkID: vlanID}
 
@@ -142,6 +163,9 @@ func (i *PortServiceOp) Unassign(portID, vlanID string) (*Port, *Response, error
 
 // Bond enables bonding for one or all ports
 func (i *PortServiceOp) Bond(portID string, bulkEnable bool) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	br := &BondRequest{BulkEnable: bulkEnable}
 	apiPath := path.Join(portBasePath, portID, "bond")
 	return i.portAction(apiPath, br)
@@ -149,6 +173,9 @@ func (i *PortServiceOp) Bond(portID string, bulkEnable bool) (*Port, *Response, 
 
 // Disbond disables bonding for one or all ports
 func (i *PortServiceOp) Disbond(portID string, bulkEnable bool) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	dr := &DisbondRequest{BulkDisable: bulkEnable}
 	apiPath := path.Join(portBasePath, portID, "disbond")
 	return i.portAction(apiPath, dr)
@@ -169,6 +196,9 @@ func (i *PortServiceOp) portAction(apiPath string, req interface{}) (*Port, *Res
 //
 // portID is the UUID of a Bonding Port
 func (i *PortServiceOp) ConvertToLayerTwo(portID string) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "convert", "layer-2")
 	port := new(Port)
 
@@ -182,6 +212,9 @@ func (i *PortServiceOp) ConvertToLayerTwo(portID string) (*Port, *Response, erro
 
 // ConvertToLayerThree converts a bond port to Layer 3. VLANs must first be unassigned.
 func (i *PortServiceOp) ConvertToLayerThree(portID string, ips []AddressRequest) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(portBasePath, portID, "convert", "layer-3")
 	port := new(Port)
 
@@ -199,6 +232,9 @@ func (i *PortServiceOp) ConvertToLayerThree(portID string, ips []AddressRequest)
 
 // Get returns a port by id
 func (s *PortServiceOp) Get(portID string, opts *GetOptions) (*Port, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	port := new(Port)

--- a/vendor/github.com/packethost/packngo/projects.go
+++ b/vendor/github.com/packethost/packngo/projects.go
@@ -93,6 +93,9 @@ func (s *ProjectServiceOp) List(opts *ListOptions) (projects []Project, resp *Re
 
 // Get returns a project by id
 func (s *ProjectServiceOp) Get(projectID string, opts *GetOptions) (*Project, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	project := new(Project)
@@ -117,6 +120,9 @@ func (s *ProjectServiceOp) Create(createRequest *ProjectCreateRequest) (*Project
 
 // Update updates a project
 func (s *ProjectServiceOp) Update(id string, updateRequest *ProjectUpdateRequest) (*Project, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, id)
 	project := new(Project)
 
@@ -130,6 +136,9 @@ func (s *ProjectServiceOp) Update(id string, updateRequest *ProjectUpdateRequest
 
 // Delete deletes a project
 func (s *ProjectServiceOp) Delete(projectID string) (*Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID)
 
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -137,6 +146,9 @@ func (s *ProjectServiceOp) Delete(projectID string) (*Response, error) {
 
 // ListBGPSessions returns all BGP Sessions associated with the project
 func (s *ProjectServiceOp) ListBGPSessions(projectID string, opts *ListOptions) (bgpSessions []BGPSession, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, bgpSessionBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -158,6 +170,9 @@ func (s *ProjectServiceOp) ListBGPSessions(projectID string, opts *ListOptions) 
 
 // ListSSHKeys returns all SSH Keys associated with the project
 func (s *ProjectServiceOp) ListSSHKeys(projectID string, opts *SearchOptions) (sshKeys []SSHKey, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 
 	endpointPath := path.Join(projectBasePath, projectID, sshKeyBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -176,6 +191,9 @@ func (s *ProjectServiceOp) ListSSHKeys(projectID string, opts *SearchOptions) (s
 
 // ListEvents returns list of project events
 func (s *ProjectServiceOp) ListEvents(projectID string, listOpt *ListOptions) ([]Event, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(projectBasePath, projectID, eventBasePath)
 
 	return listEvents(s.client, apiPath, listOpt)

--- a/vendor/github.com/packethost/packngo/spotmarketrequest.go
+++ b/vendor/github.com/packethost/packngo/spotmarketrequest.go
@@ -65,6 +65,9 @@ func roundPlus(f float64, places int) float64 {
 }
 
 func (s *SpotMarketRequestServiceOp) Create(cr *SpotMarketRequestCreateRequest, pID string) (*SpotMarketRequest, *Response, error) {
+	if validateErr := ValidateUUID(pID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	opts := (&GetOptions{}).Including("devices", "project", "plan")
 	endpointPath := path.Join(projectBasePath, pID, spotMarketRequestBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
@@ -81,6 +84,9 @@ func (s *SpotMarketRequestServiceOp) Create(cr *SpotMarketRequestCreateRequest, 
 }
 
 func (s *SpotMarketRequestServiceOp) List(pID string, opts *ListOptions) ([]SpotMarketRequest, *Response, error) {
+	if validateErr := ValidateUUID(pID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	type smrRoot struct {
 		SMRs []SpotMarketRequest `json:"spot_market_requests"`
 	}
@@ -98,6 +104,9 @@ func (s *SpotMarketRequestServiceOp) List(pID string, opts *ListOptions) ([]Spot
 }
 
 func (s *SpotMarketRequestServiceOp) Get(id string, opts *GetOptions) (*SpotMarketRequest, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(spotMarketRequestBasePath, id)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	smr := new(SpotMarketRequest)
@@ -111,6 +120,9 @@ func (s *SpotMarketRequestServiceOp) Get(id string, opts *GetOptions) (*SpotMark
 }
 
 func (s *SpotMarketRequestServiceOp) Delete(id string, forceDelete bool) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(spotMarketRequestBasePath, id)
 	var params *map[string]bool
 	if forceDelete {

--- a/vendor/github.com/packethost/packngo/sshkeys.go
+++ b/vendor/github.com/packethost/packngo/sshkeys.go
@@ -79,6 +79,9 @@ func (s *SSHKeyServiceOp) list(url string) ([]SSHKey, *Response, error) {
 // ProjectList lists ssh keys of a project
 // Deprecated: Use ProjectServiceOp.ListSSHKeys
 func (s *SSHKeyServiceOp) ProjectList(projectID string) ([]SSHKey, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	return s.list(path.Join(projectBasePath, projectID, sshKeyBasePath))
 
 }
@@ -90,6 +93,9 @@ func (s *SSHKeyServiceOp) List() ([]SSHKey, *Response, error) {
 
 // Get returns an ssh key by id
 func (s *SSHKeyServiceOp) Get(sshKeyID string, opts *GetOptions) (*SSHKey, *Response, error) {
+	if validateErr := ValidateUUID(sshKeyID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(sshKeyBasePath, sshKeyID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	sshKey := new(SSHKey)
@@ -120,6 +126,9 @@ func (s *SSHKeyServiceOp) Create(createRequest *SSHKeyCreateRequest) (*SSHKey, *
 
 // Update updates an ssh key
 func (s *SSHKeyServiceOp) Update(id string, updateRequest *SSHKeyUpdateRequest) (*SSHKey, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	if updateRequest.Label == nil && updateRequest.Key == nil {
 		return nil, nil, fmt.Errorf("You must set either Label or Key string for SSH Key update")
 	}
@@ -137,6 +146,9 @@ func (s *SSHKeyServiceOp) Update(id string, updateRequest *SSHKeyUpdateRequest) 
 
 // Delete deletes an ssh key
 func (s *SSHKeyServiceOp) Delete(sshKeyID string) (*Response, error) {
+	if validateErr := ValidateUUID(sshKeyID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(sshKeyBasePath, sshKeyID)
 
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)

--- a/vendor/github.com/packethost/packngo/user.go
+++ b/vendor/github.com/packethost/packngo/user.go
@@ -68,6 +68,21 @@ type User struct {
 	Staff                 bool    `json:"staff,omitempty"`
 }
 
+// UserLite is an abbreviated listing of an Equinix Metal user
+type UserLite struct {
+	*Href          `json:",inline"`
+	ID             string     `json:"id"`
+	ShortID        string     `json:"short_id"`
+	FirstName      string     `json:"first_name,omitempty"`
+	LastName       string     `json:"last_name,omitempty"`
+	FullName       string     `json:"full_name,omitempty"`
+	Email          string     `json:"email,omitempty"`
+	CreatedAt      *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt      *Timestamp `json:"updated_at,omitempty"`
+	Level          string     `json:"level,omitempty"`
+	AvatarThumbURL string     `json:"avatar_thumb_url,omitempty"`
+}
+
 // UserUpdateRequest struct for UserService.Update
 type UserUpdateRequest struct {
 	FirstName   *string      `json:"first_name,omitempty"`
@@ -122,6 +137,9 @@ func (s *UserServiceOp) Current() (*User, *Response, error) {
 }
 
 func (s *UserServiceOp) Get(userID string, opts *GetOptions) (*User, *Response, error) {
+	if validateErr := ValidateUUID(userID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(usersBasePath, userID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	user := new(User)

--- a/vendor/github.com/packethost/packngo/utils.go
+++ b/vendor/github.com/packethost/packngo/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"regexp"
 )
 
 var (
@@ -151,6 +152,15 @@ func stringifyValue(w io.Writer, val reflect.Value) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// validate UUID
+func ValidateUUID(uuid string) error {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+	if !r.MatchString(uuid) {
+		return fmt.Errorf("%s is not a valid UUID", uuid)
 	}
 	return nil
 }

--- a/vendor/github.com/packethost/packngo/virtualcircuits.go
+++ b/vendor/github.com/packethost/packngo/virtualcircuits.go
@@ -88,28 +88,49 @@ func (s *VirtualCircuitServiceOp) do(method, apiPathQuery string, req interface{
 }
 
 func (s *VirtualCircuitServiceOp) Update(vcID string, req *VCUpdateRequest, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	if validateErr := ValidateUUID(vcID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(virtualCircuitBasePath, vcID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	return s.do("PUT", apiPathQuery, req)
 }
 
 func (s *VirtualCircuitServiceOp) Events(id string, opts *GetOptions) ([]Event, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(virtualCircuitBasePath, id, eventBasePath)
 	return listEvents(s.client, apiPath, opts)
 }
 
 func (s *VirtualCircuitServiceOp) Get(id string, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(virtualCircuitBasePath, id)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	return s.do("GET", apiPathQuery, nil)
 }
 
 func (s *VirtualCircuitServiceOp) Delete(id string) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(virtualCircuitBasePath, id)
 	return s.client.DoRequest("DELETE", apiPath, nil, nil)
 }
 
 func (s *VirtualCircuitServiceOp) Create(projectID, connID, portID string, request *VCCreateRequest, opts *GetOptions) (*VirtualCircuit, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(connID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, connectionBasePath, connID, portBasePath, portID, virtualCircuitBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	return s.do("POST", apiPathQuery, request)

--- a/vendor/github.com/packethost/packngo/virtualnetworks.go
+++ b/vendor/github.com/packethost/packngo/virtualnetworks.go
@@ -11,7 +11,6 @@ type ProjectVirtualNetworkService interface {
 	List(projectID string, opts *ListOptions) (*VirtualNetworkListResponse, *Response, error)
 	Create(*VirtualNetworkCreateRequest) (*VirtualNetwork, *Response, error)
 	Get(string, *GetOptions) (*VirtualNetwork, *Response, error)
-	GetByVXLAN(string, int, *GetOptions) (*VirtualNetwork, *Response, error)
 	Delete(virtualNetworkID string) (*Response, error)
 }
 
@@ -115,24 +114,4 @@ func (i *ProjectVirtualNetworkServiceOp) Delete(virtualNetworkID string) (*Respo
 	}
 
 	return resp, nil
-}
-
-// list project vlans and return the one with matching vxlan
-func (i *ProjectVirtualNetworkServiceOp) GetByVXLAN(projectID string, vxlan int, opts *GetOptions) (*VirtualNetwork, *Response, error) {
-	endpointPath := path.Join(projectBasePath, projectID, virtualNetworkBasePath)
-	apiPathQuery := opts.WithQuery(endpointPath)
-	vlanList := new(VirtualNetworkListResponse)
-
-	resp, err := i.client.DoRequest("GET", apiPathQuery, nil, vlanList)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	for _, vlan := range vlanList.VirtualNetworks {
-		if vlan.VXLAN == vxlan {
-			return &vlan, resp, nil
-		}
-	}
-
-	return nil, resp, nil
 }

--- a/vendor/github.com/packethost/packngo/vlan_assignments.go
+++ b/vendor/github.com/packethost/packngo/vlan_assignments.go
@@ -117,6 +117,9 @@ type VLANAssignmentCreateRequest struct {
 
 // List returns VLANAssignmentBatches
 func (s *VLANAssignmentServiceOp) ListBatch(portID string, opts *ListOptions) (results []VLANAssignmentBatch, resp *Response, err error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -138,6 +141,12 @@ func (s *VLANAssignmentServiceOp) ListBatch(portID string, opts *ListOptions) (r
 
 // Get returns a VLANAssignmentBatch by id
 func (s *VLANAssignmentServiceOp) GetBatch(portID, batchID string, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(batchID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath, batchID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	batch := new(VLANAssignmentBatch)
@@ -150,6 +159,9 @@ func (s *VLANAssignmentServiceOp) GetBatch(portID, batchID string, opts *GetOpti
 
 // Create creates VLANAssignmentBatch objects
 func (s *VLANAssignmentServiceOp) CreateBatch(portID string, request *VLANAssignmentBatchCreateRequest, opts *GetOptions) (*VLANAssignmentBatch, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, portVLANAssignmentsBatchPath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	batch := new(VLANAssignmentBatch)
@@ -162,6 +174,9 @@ func (s *VLANAssignmentServiceOp) CreateBatch(portID string, request *VLANAssign
 
 // List returns VLANAssignment
 func (s *VLANAssignmentServiceOp) List(portID string, opts *ListOptions) (results []VLANAssignment, resp *Response, err error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 
@@ -183,6 +198,12 @@ func (s *VLANAssignmentServiceOp) List(portID string, opts *ListOptions) (result
 
 // Get returns a VLANAssignment by id
 func (s *VLANAssignmentServiceOp) Get(portID, assignmentID string, opts *GetOptions) (*VLANAssignment, *Response, error) {
+	if validateErr := ValidateUUID(portID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(assignmentID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(portBasePath, portID, portVLANAssignmentsPath, assignmentID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	VLANAssignment := new(VLANAssignment)

--- a/vendor/github.com/packethost/packngo/volumes.go
+++ b/vendor/github.com/packethost/packngo/volumes.go
@@ -110,6 +110,9 @@ type VolumeServiceOp struct {
 
 // List returns the volumes for a project
 func (v *VolumeServiceOp) List(projectID string, opts *ListOptions) (volumes []Volume, resp *Response, err error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(projectBasePath, projectID, volumeBasePath)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	for {
@@ -131,6 +134,9 @@ func (v *VolumeServiceOp) List(projectID string, opts *ListOptions) (volumes []V
 
 // Get returns a volume by id
 func (v *VolumeServiceOp) Get(volumeID string, opts *GetOptions) (*Volume, *Response, error) {
+	if validateErr := ValidateUUID(volumeID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(volumeBasePath, volumeID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	volume := new(Volume)
@@ -145,6 +151,9 @@ func (v *VolumeServiceOp) Get(volumeID string, opts *GetOptions) (*Volume, *Resp
 
 // Update updates a volume
 func (v *VolumeServiceOp) Update(id string, updateRequest *VolumeUpdateRequest) (*Volume, *Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	apiPath := path.Join(volumeBasePath, id)
 	volume := new(Volume)
 
@@ -158,6 +167,9 @@ func (v *VolumeServiceOp) Update(id string, updateRequest *VolumeUpdateRequest) 
 
 // Delete deletes a volume
 func (v *VolumeServiceOp) Delete(volumeID string) (*Response, error) {
+	if validateErr := ValidateUUID(volumeID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(volumeBasePath, volumeID)
 
 	return v.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -165,6 +177,9 @@ func (v *VolumeServiceOp) Delete(volumeID string) (*Response, error) {
 
 // Create creates a new volume for a project
 func (v *VolumeServiceOp) Create(createRequest *VolumeCreateRequest, projectID string) (*Volume, *Response, error) {
+	if validateErr := ValidateUUID(projectID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	url := path.Join(projectBasePath, projectID, volumeBasePath)
 	volume := new(Volume)
 
@@ -180,6 +195,12 @@ func (v *VolumeServiceOp) Create(createRequest *VolumeCreateRequest, projectID s
 
 // Create Attachment, i.e. attach volume to a device
 func (v *VolumeAttachmentServiceOp) Create(volumeID, deviceID string) (*VolumeAttachment, *Response, error) {
+	if validateErr := ValidateUUID(volumeID); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	if validateErr := ValidateUUID(deviceID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	url := path.Join(volumeBasePath, volumeID, attachmentsBasePath)
 	volAttachParam := map[string]string{
 		"device_id": deviceID,
@@ -195,6 +216,9 @@ func (v *VolumeAttachmentServiceOp) Create(volumeID, deviceID string) (*VolumeAt
 
 // Get gets attachment by id
 func (v *VolumeAttachmentServiceOp) Get(attachmentID string, opts *GetOptions) (*VolumeAttachment, *Response, error) {
+	if validateErr := ValidateUUID(attachmentID); validateErr != nil {
+		return nil, nil, validateErr
+	}
 	endpointPath := path.Join(volumeBasePath, attachmentsBasePath, attachmentID)
 	apiPathQuery := opts.WithQuery(endpointPath)
 	volumeAttachment := new(VolumeAttachment)
@@ -209,6 +233,9 @@ func (v *VolumeAttachmentServiceOp) Get(attachmentID string, opts *GetOptions) (
 
 // Delete deletes attachment by id
 func (v *VolumeAttachmentServiceOp) Delete(attachmentID string) (*Response, error) {
+	if validateErr := ValidateUUID(attachmentID); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(volumeBasePath, attachmentsBasePath, attachmentID)
 
 	return v.client.DoRequest("DELETE", apiPath, nil, nil)
@@ -216,6 +243,9 @@ func (v *VolumeAttachmentServiceOp) Delete(attachmentID string) (*Response, erro
 
 // Lock sets a volume to "locked"
 func (v *VolumeServiceOp) Lock(id string) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(volumeBasePath, id)
 	action := lockType{Locked: true}
 
@@ -224,6 +254,9 @@ func (v *VolumeServiceOp) Lock(id string) (*Response, error) {
 
 // Unlock sets a volume to "unlocked"
 func (v *VolumeServiceOp) Unlock(id string) (*Response, error) {
+	if validateErr := ValidateUUID(id); validateErr != nil {
+		return nil, validateErr
+	}
 	apiPath := path.Join(volumeBasePath, id)
 	action := lockType{Locked: false}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/packethost/packngo v0.19.2-0.20210922152159-b073e9ef6568 => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc
+# github.com/packethost/packngo v0.20.1-0.20220109151846-46c24be88530
 ## explicit
 github.com/packethost/packngo
 # github.com/ulikunitz/xz v0.5.8
@@ -404,4 +404,3 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
-# github.com/packethost/packngo => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/packethost/packngo v0.19.1
+# github.com/packethost/packngo v0.19.2-0.20210922152159-b073e9ef6568 => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc
 ## explicit
 github.com/packethost/packngo
 # github.com/ulikunitz/xz v0.5.8
@@ -404,3 +404,4 @@ google.golang.org/protobuf/types/known/durationpb
 google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 google.golang.org/protobuf/types/pluginpb
+# github.com/packethost/packngo => github.com/t0mk/packngo v0.0.0-20220103111840-26c097341bbc


### PR DESCRIPTION
This PR adds Fabric service token support to metal_connection resource and datasource.

I also changed attribute validation in metal_connection, according to my understanding of what has changed (in `resourceMetalConnectionCreate`)

There are 2 things to do before this can be merged:

- This PR is blocked by https://github.com/packethost/packngo/issues/317, because right now it's not possible to read project ID for a created connection. Once the `project` attribute is added to Connection resoruce in EM API, it should be added to packngo, and then the read of `project_id` in `resourceMetalConnectionRead` in `metal/resource_metal_connection.go` should be updated.

- Update go mod dependency when the fabric service token support is released in packngo.