### PR TITLE
wait for IP Reservations to reach the desired state

### DIFF
--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -94,6 +94,8 @@ The following arguments are supported:
 * `metro` - (Optional) Metro where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4, conflicts with `facility`
 * `description` - (Optional) Arbitrary description
 * `tags` - (Optional) String list of tags
+* `wait_for_state` - (Optional) Wait for the IP reservation block to reach a desired state on resource creation. One of: `pending`, `created`. The `created` state is default and recommended if the addresses are needed within the configuration. An error will be returned if a timeout or the `denied` state is encountered.
+* `custom_data` - (Optional) Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.
 
 ## Attributes Reference
 

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -62,11 +62,6 @@ func metalIPComputedFields() map[string]*schema.Schema {
 
 func metalIPResourceComputedFields() map[string]*schema.Schema {
 	s := metalIPComputedFields()
-	s["address_family"] = &schema.Schema{
-		Type:        schema.TypeInt,
-		Computed:    true,
-		Description: "Address family as integer (4 or 6)",
-	}
 	s["public"] = &schema.Schema{
 		Type:        schema.TypeBool,
 		Computed:    true,

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -59,6 +59,8 @@ func metalIPComputedFields() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Description: "Wait for the IP reservation block to reach a desired state on resource creation. One of: `pending`, `created`. The `created` state is default and recommended if the addresses are needed within the configuration. An error will be returned if a timeout or the `denied` state is encountered.",
 			Default:     packngo.IPReservationStateCreated,
+			Optional:    true,
+			ForceNew:    false,
 			ValidateDiagFunc: validation.ToDiagFunc(
 				validation.StringInSlice([]string{
 					string(packngo.IPReservationStateCreated),

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/packethost/packngo"
 )
@@ -164,12 +165,13 @@ func resourceMetalReservedIPBlock() *schema.Resource {
 	}
 
 	reservedBlockSchema["custom_data"] = &schema.Schema{
-		Type:         schema.TypeSet,
-		ForceNew:     false,
-		Description:  "Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.",
-		Optional:     true,
-		ValidateFunc: validation.StringIsJSON,
-		Elem:         &schema.Schema{Type: schema.TypeString},
+		Type:             schema.TypeSet,
+		ForceNew:         false,
+		Description:      "Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.",
+		Optional:         true,
+		ValidateFunc:     validation.StringIsJSON,
+		DiffSuppressFunc: structure.SuppressJsonDiff,
+		Elem:             &schema.Schema{Type: schema.TypeString},
 	}
 
 	reservedBlockSchema["wait_for_state"] = &schema.Schema{

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -165,7 +165,8 @@ func resourceMetalReservedIPBlock() *schema.Resource {
 	}
 
 	reservedBlockSchema["custom_data"] = &schema.Schema{
-		Type:             schema.TypeSet,
+		Type:             schema.TypeString,
+		Default:          "{}",
 		ForceNew:         false,
 		Description:      "Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.",
 		Optional:         true,

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -21,6 +21,9 @@ resource "metal_reserved_ip_block" "test" {
 	type        = "global_ipv4"
 	description = "testdesc"
 	quantity    = 1
+	custom_data = jsonencode({
+		"foo": "bar"
+	})
 }`, name)
 }
 
@@ -77,6 +80,8 @@ func TestAccMetalReservedIPBlock_Global(t *testing.T) {
 						"metal_reserved_ip_block.test", "public", "true"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "management", "false"),
+					resource.TestCheckResourceAttr(
+						"metal_reserved_ip_block.test", "custom_data", `{"foo":"bar"}`),
 				),
 			},
 		},
@@ -148,9 +153,10 @@ func TestAccMetalReservedIPBlock_ImportBasic(t *testing.T) {
 				Config: testAccCheckMetalReservedIPBlockConfig_Public(rs),
 			},
 			{
-				ResourceName:      "metal_reserved_ip_block.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "metal_reserved_ip_block.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},
 	})


### PR DESCRIPTION
This PR adds various features to `metal_reserved_ip_block`:
* Adds `custom_data` (a string of JSON. This enables the use of arbitrary scalar, list, and map types, as supported by the API. This is defaulted to the API default of `"{}"`.
* Allows for `tags`, `description`, and `custom_data` to be updated
* Adds `wait_for_state` (defaults to `created`)
* The default behavior is now to wait for the IP Address reservation to be usable (guaranteeing an IP Address) before exiting the create call. A number of users have been snagged by this resource releasing after creating the reservation request without having an IP address fully reserved.  Those users will now get a 10m timeout (default, configurable with `timeouts`) unless they set `wait_for_state="pending"`

Fixes #135