### PR TITLE
wait_for_reservation_deprovision should succeed if a different instance id is found

### DIFF
--- a/metal/helpers_device.go
+++ b/metal/helpers_device.go
@@ -2,6 +2,7 @@ package metal
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"time"
@@ -128,13 +129,10 @@ func hwReservationStateRefreshFunc(client *packngo.Client, reservationId, instan
 		case r != nil && r.Provisionable:
 			state = provisionable
 		case r != nil && r.Device != nil && (r.Device.ID != "" && r.Device.ID != instanceId):
+			log.Printf("[WARN] Equinix Metal device instance %s (reservation %s) was reprovisioned to a another instance (%s)", instanceId, reservationId, r.Device.ID)
 			state = reprovisioned
 		}
-		p := false
-		if r != nil {
-			p = r.Provisionable
-		}
-		fmt.Println("provisionable", p, "state", state, "err", err, "reservation", r)
+
 		return r, state, err
 	}
 }

--- a/metal/helpers_device_test.go
+++ b/metal/helpers_device_test.go
@@ -1,0 +1,149 @@
+package metal
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/packethost/packngo"
+)
+
+type mockHWService struct {
+	GetFn  func(string, *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error)
+	ListFn func(string, *packngo.ListOptions) ([]packngo.HardwareReservation, *packngo.Response, error)
+	MoveFn func(string, string) (*packngo.HardwareReservation, *packngo.Response, error)
+}
+
+func (m *mockHWService) Get(id string, opt *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+	return m.GetFn(id, opt)
+}
+func (m *mockHWService) List(project string, opt *packngo.ListOptions) ([]packngo.HardwareReservation, *packngo.Response, error) {
+	return m.ListFn(project, opt)
+}
+func (m *mockHWService) Move(id string, dest string) (*packngo.HardwareReservation, *packngo.Response, error) {
+	return m.MoveFn(id, dest)
+}
+
+var _ packngo.HardwareReservationService = (*mockHWService)(nil)
+
+func Test_waitUntilReservationProvisionable(t *testing.T) {
+	type args struct {
+		reservationId string
+		instanceId    string
+		meta          *packngo.Client
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "error",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: &mockHWService{
+						GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							return nil, nil, fmt.Errorf("boom")
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "provisionable",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: (func() *mockHWService {
+						invoked := new(int)
+
+						responses := map[int]struct {
+							id            string
+							provisionable bool
+						}{
+							0: {"instanceId", false}, // should retry
+							1: {"", true},            // should return success
+						}
+
+						return &mockHWService{
+							GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+								response := responses[*invoked]
+								*invoked++
+
+								return &packngo.HardwareReservation{
+									Device: &packngo.Device{ID: response.id}, Provisionable: response.provisionable,
+								}, nil, nil
+							},
+						}
+					})(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reprovisioned",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: (func() *mockHWService {
+						responses := map[int]struct {
+							id            string
+							provisionable bool
+						}{
+							0: {"instanceId", false},      // should retry
+							1: {"new instance id", false}, // should return success
+						}
+						invoked := new(int)
+
+						return &mockHWService{
+							GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+								response := responses[*invoked]
+								*invoked++
+								fmt.Println("GAHTEST", *invoked)
+
+								return &packngo.HardwareReservation{
+									Device: &packngo.Device{ID: response.id}, Provisionable: response.provisionable,
+								}, nil, nil
+							},
+						}
+					})(),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "foreverDeprovisioning",
+			args: args{
+				reservationId: "reservationId",
+				instanceId:    "instanceId",
+				meta: &packngo.Client{
+					HardwareReservations: &mockHWService{
+						GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							return &packngo.HardwareReservation{
+								Device: nil, Provisionable: false,
+							}, nil, nil
+
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	// delay and minTimeout * 2 should be less than timeout for each test.
+	// timeout * number of tests that reach timeout must be less than 30s (default go test timeout).
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := waitUntilReservationProvisionable(tt.args.meta, tt.args.reservationId, tt.args.instanceId, 50*time.Millisecond, 1*time.Second, 50*time.Millisecond); (err != nil) != tt.wantErr {
+				t.Errorf("waitUntilReservationProvisionable() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/metal/helpers_device_test.go
+++ b/metal/helpers_device_test.go
@@ -105,7 +105,6 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 							GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
 								response := responses[*invoked]
 								*invoked++
-								fmt.Println("GAHTEST", *invoked)
 
 								return &packngo.HardwareReservation{
 									Device: &packngo.Device{ID: response.id}, Provisionable: response.provisionable,

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -782,7 +782,7 @@ func resourceMetalDeviceDelete(d *schema.ResourceData, meta interface{}) error {
 	if resIdOk {
 		wfrd, wfrdOK := d.GetOk("wait_for_reservation_deprovision")
 		if wfrdOK && wfrd.(bool) {
-			err := waitUntilReservationProvisionable(resId.(string), meta)
+			err := waitUntilReservationProvisionable(resId.(string), d.Id(), meta)
 			if err != nil {
 				return err
 			}

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -782,7 +782,7 @@ func resourceMetalDeviceDelete(d *schema.ResourceData, meta interface{}) error {
 	if resIdOk {
 		wfrd, wfrdOK := d.GetOk("wait_for_reservation_deprovision")
 		if wfrdOK && wfrd.(bool) {
-			err := waitUntilReservationProvisionable(resId.(string), d.Id(), meta)
+			err := waitUntilReservationProvisionable(client, resId.(string), d.Id(), 10*time.Second, 60*time.Minute, 3*time.Second)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #208 

When a Device Instance uses a Hardware Reservation ID, the `wait_for_reservation_deprovision` parameter can be set to instruct the Terraform provider to not release the `metal_device` delete process until the hardware reservation has reached the `provisionable` state.  The hardware reservation API resource will be polled on a refresh cycle until it is found in `provisionable=true` state.

In some user-scenarios, the hardware reservation may be reassigned by another user or other software while this Terraform provider is polling.  When this occurs, the resource may never reach `provisionable=true`.

From a Terraform user perspective, the best behavior the provider can ascribe to this scenario is to stop polling when `provisionable=false` is detected but the reservation's `instance.ID` no longer matches the instance ID that was being deleted.  The deprovision cycle has been completed, so Terraform should move on.  If the user intended to reuse that reservation in their own configuration, the recreation phase will return an error that the reservation is already in use.

This PR adds this behavior and mock tests to verify the behavior.
A log message will `WARN` if a reprovisioned reservation has been detected.