### PR TITLE
include device filter in hwReservationStateRefreshFunc

### DIFF
--- a/metal/helpers_device.go
+++ b/metal/helpers_device.go
@@ -120,7 +120,7 @@ const (
 
 func hwReservationStateRefreshFunc(client *packngo.Client, reservationId, instanceId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		r, _, err := client.HardwareReservations.Get(reservationId, nil)
+		r, _, err := client.HardwareReservations.Get(reservationId, &packngo.GetOptions{Includes: []string{"device"}})
 		state := deprovisioning
 		switch {
 		case err != nil:
@@ -224,14 +224,14 @@ func powerOnAndWait(d *schema.ResourceData, meta interface{}) error {
 	}
 	state := d.Get("state").(string)
 	if state != "active" {
-		return friendlyError(fmt.Errorf("Device in non-active state \"%s\"", state))
+		return friendlyError(fmt.Errorf("device in non-active state \"%s\"", state))
 	}
 	return nil
 }
 
 func validateFacilityForDevice(v interface{}, k string) (ws []string, errors []error) {
 	if v.(string) == "any" {
-		errors = append(errors, fmt.Errorf(`Cannot use facility: "any"`))
+		errors = append(errors, fmt.Errorf(`cannot use facility: "any"`))
 	}
 	return
 }

--- a/metal/helpers_device_test.go
+++ b/metal/helpers_device_test.go
@@ -71,12 +71,16 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 						}
 
 						return &mockHWService{
-							GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							GetFn: func(_ string, opts *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
 								response := responses[*invoked]
 								*invoked++
 
+								var device *packngo.Device
+								if opts != nil && contains(opts.Includes, "device") {
+									device = &packngo.Device{ID: response.id}
+								}
 								return &packngo.HardwareReservation{
-									Device: &packngo.Device{ID: response.id}, Provisionable: response.provisionable,
+									Device: device, Provisionable: response.provisionable,
 								}, nil, nil
 							},
 						}
@@ -102,12 +106,16 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 						invoked := new(int)
 
 						return &mockHWService{
-							GetFn: func(_ string, _ *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
+							GetFn: func(_ string, opts *packngo.GetOptions) (*packngo.HardwareReservation, *packngo.Response, error) {
 								response := responses[*invoked]
 								*invoked++
 
+								var device *packngo.Device
+								if opts != nil && contains(opts.Includes, "device") {
+									device = &packngo.Device{ID: response.id}
+								}
 								return &packngo.HardwareReservation{
-									Device: &packngo.Device{ID: response.id}, Provisionable: response.provisionable,
+									Device: device, Provisionable: response.provisionable,
 								}, nil, nil
 							},
 						}
@@ -127,7 +135,6 @@ func Test_waitUntilReservationProvisionable(t *testing.T) {
 							return &packngo.HardwareReservation{
 								Device: nil, Provisionable: false,
 							}, nil, nil
-
 						},
 					},
 				},


### PR DESCRIPTION
This PR aims to fix https://github.com/equinix/terraform-provider-metal/issues/208 and is related to https://github.com/equinix/terraform-provider-metal/pull/211

As described in the issue, get function was taking a nil packngo.GetOptions and therefore returning a nil Device
required to check it Device ID has changed.

https://github.com/equinix/terraform-provider-metal/blob/edc45fee397d331d03bdd3722b52641cd4354936/metal/helpers_device.go#L123

It has been replaced:

`r, _, err := client.HardwareReservations.Get(reservationId, &packngo.GetOptions{Includes: []string{"device"}})`