### PR TITLE
backport VRF support from equinix/equinix provider

### DIFF
--- a/docs/data-sources/gateway.md
+++ b/docs/data-sources/gateway.md
@@ -9,6 +9,8 @@ description: |-
 
 Use this datasource to retrieve Metal Gateway resources in Equinix Metal.
 
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
 ## Example Usage
 
 ```hcl
@@ -36,3 +38,4 @@ data "metal_gateway" "test" {
 * `ip_reservation_id` - UUID of IP reservation block bound to the gateway
 * `private_ipv4_subnet_size` - Size of the private IPv4 subnet bound to this metal gateway, one of (8, 16, 32, 64, 128)`
 * `state` - Status of the gateway resource
+* `vrf_id` - UUID of the VRF associated with the IP Reservation.

--- a/docs/data-sources/gateway.md
+++ b/docs/data-sources/gateway.md
@@ -23,7 +23,7 @@ resource "metal_vlan" "test" {
 }
 
 data "metal_gateway" "test" {
-  gateway_id               = local.gateway_id
+  gateway_id = local.gateway_id
 }
 ```
 

--- a/docs/data-sources/reserved_ip_block.md
+++ b/docs/data-sources/reserved_ip_block.md
@@ -9,6 +9,8 @@ Look up an IP address block
 
 Use this data source to find IP address blocks in Equinix Metal. You can use IP address or a block ID for lookup.
 
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
 ## Example Usage
 
 Look up an IP address for a domain name, then use the IP to look up the containing IP block and run a device with IP address from the block:
@@ -43,5 +45,6 @@ You should pass either `id`, or both `project_id` and `ip_address`.
 
 ## Attributes Reference
 
-This datasource exposes the same attributes as the [metal_reserved_ip_block resource](../resources/reserved_ip_block.md).
+This datasource exposes the same attributes as the [metal_reserved_ip_block resource](../resources/reserved_ip_block.md), with the following differences:
 
+* `type` - One of `global_ipv4`, `public_ipv4`, `private_ipv4`, `public_ipv6`,or `vrf`

--- a/docs/data-sources/reserved_ip_block.md
+++ b/docs/data-sources/reserved_ip_block.md
@@ -37,11 +37,11 @@ resource "metal_device" "www" {
 
 ## Argument Reference
 
-You should pass either `id`, or both `project_id` and `ip_address`.
+* `id` - (Optional) UUID of the IP address block to look up
+* `project_id` - (Optional) UUID of the project where the searched block should be
+* `ip_address` - (Optional) Block containing this IP address will be returned
 
-* `id` - (Required) UUID of the IP address block to look up
-* `project_id` - (Required) UUID of the project where the searched block should be
-* `ip_address` - (Required) Block containing this IP address will be returned
+-> **NOTE:** You should pass either `id`, or both `project_id` and `ip_address`.
 
 ## Attributes Reference
 

--- a/docs/data-sources/virtual_circuit.md
+++ b/docs/data-sources/virtual_circuit.md
@@ -9,6 +9,8 @@ description: |-
 
 Use this data source to retrieve a virtual circuit resource from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
 ## Example Usage
 
 ```hcl
@@ -35,3 +37,13 @@ data "metal_virtual_circuit" "example_vc" {
 * `tags` - Tags for the Virtual Circuit resource
 * `speed` - Speed of the Virtual Circuit resource
 
+* `vrf_id` - UUID of the VLAN to associate.
+* `peer_asn` - The BGP ASN of the peer. The same ASN may be the used across several VCs, but it cannot be the same as the local_asn of the VRF.
+* `subnet` - A subnet from one of the IP
+  blocks associated with the VRF that we will help create an IP reservation for. Can only be either a /30 or /31.
+  * For a /31 block, it will only have two IP addresses, which will be used for
+  the metal_ip and customer_ip.
+  * For a /30 block, it will have four IP addresses, but the first and last IP addresses are not usable. We will default to the first usable IP address for the metal_ip.
+* `metal_ip` - The IP address that’s set as “our” IP that is configured on the rack_local_vlan SVI. Will default to the first usable IP in the subnet.
+* `customer_ip` - The IP address set as the customer IP which the CSR switch will peer with. Will default to the other usable IP in the subnet.
+* `md5` - The password that can be set for the VRF BGP peer

--- a/docs/data-sources/virtual_circuit.md
+++ b/docs/data-sources/virtual_circuit.md
@@ -9,13 +9,13 @@ description: |-
 
 Use this data source to retrieve a virtual circuit resource from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 
-~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+-> **NOTE:** VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
 
 ## Example Usage
 
 ```hcl
 data "metal_connection" "example_connection" {
-  connection_id     = "4347e805-eb46-4699-9eb9-5c116e6a017d"
+  connection_id = "4347e805-eb46-4699-9eb9-5c116e6a017d"
 }
 
 data "metal_virtual_circuit" "example_vc" {
@@ -26,17 +26,21 @@ data "metal_virtual_circuit" "example_vc" {
 
 ## Argument Reference
 
+The following arguments are supported:
+
 * `virtual_circuit_id` - (Required) ID of the virtual circuit resource
+
 ## Attributes Reference
 
-* `name` - Name of the virtual circuit resource
-* `status` - Status of the virtal circuit
-* `project_id` - ID of project to which the VC belongs
-* `vnid`, `nni_vlan`, `nni_nvid` - VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/)
-* `description` - Description for the Virtual Circuit resource
-* `tags` - Tags for the Virtual Circuit resource
-* `speed` - Speed of the Virtual Circuit resource
+In addition to all arguments above, the following attributes are exported:
 
+* `name` - Name of the virtual circuit resource.
+* `status` - Status of the virtal circuit.
+* `project_id` - ID of project to which the VC belongs.
+* `vnid`, `nni_vlan`, `nni_nvid` - VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
+* `description` - Description for the Virtual Circuit resource.
+* `tags` - Tags for the Virtual Circuit resource.
+* `speed` - Speed of the Virtual Circuit resource.
 * `vrf_id` - UUID of the VLAN to associate.
 * `peer_asn` - The BGP ASN of the peer. The same ASN may be the used across several VCs, but it cannot be the same as the local_asn of the VRF.
 * `subnet` - A subnet from one of the IP

--- a/docs/data-sources/vrf.md
+++ b/docs/data-sources/vrf.md
@@ -1,0 +1,37 @@
+---
+page_title: "Equinix Metal: metal_vrf"
+subcategory: ""
+description: |-
+  (not-GA) Provides a datasource for Equinix Metal VRF.
+---
+
+# metal_virtual_circuit (Data Source)
+
+Use this data source to retrieve a VRF resource.
+
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
+## Example Usage
+
+```hcl
+data "metal_vrf" "example_vrf" {
+  vrf_id = "48630899-9ff2-4ce6-a93f-50ff4ebcdf6e"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vrf_id` - (Required) ID of the VRF resource
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `name` - User-supplied name of the VRF, unique to the project
+* `metro` - Metro ID or Code where the VRF will be deployed.
+* `project_id` - Project ID where the VRF will be deployed.
+* `description` - Description of the VRF.
+* `local_asn` - The 4-byte ASN set on the VRF.
+* `ip_ranges` - All IPv4 and IPv6 Ranges that will be available to BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must not overlap other ranges within the VRF.

--- a/docs/guides/migration_guide_facilities_to_metros_devices.md
+++ b/docs/guides/migration_guide_facilities_to_metros_devices.md
@@ -13,7 +13,7 @@ Before the introduction of metros, resources were deployed to a single `facility
 
 ## Changing your Terraform templates to use metros instead of facilities
 
-To take advantage of some of the features of the metro, you might want to change the configuration of your Terraform templates so that the devices have `metro` specified instead of `facilities`. As both of the `metro` and `facilities` are ForceNew paramters (a change will trigger re-creation of the resource), you should be cautious if you don't want to have the device destroyed. 
+To take advantage of some of the features of the metro, you might want to change the configuration of your Terraform templates so that the devices have `metro` specified instead of `facilities`. As both of the `metro` and `facilities` are ForceNew parameters (a change will trigger re-creation of the resource), you should be cautious if you don't want to have the device destroyed.
 
 We updated the `metal_device` resource so that the change should be seamless, but please proceed with care. The `metro` parameter is also a computed attribute, and if you use newer provider version than 3.2.1, the `metro` attribute is actually present in your resource. You then only need to add it explicitly to your configuration.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ terraform {
 provider "metal" {
   auth_token = var.auth_token
 }
+# Credentials for all Equinix resources
 
 data "metal_project" "project" {
   name = "My Project"
@@ -37,6 +38,16 @@ data "metal_project" "project" {
 
 # If you want to create a fresh project, you can create one with metal_project
 #
+Client ID and Client Secret can be omitted when the only Equinix resources
+consumed are Equinix Metal resources.
+
+```hcl
+# Credentials for only Equinix Metal resources
+provider "equinix" {
+  auth_token    = "someEquinixMetalToken"
+}
+```
+
 # resource "metal_project" "cool_project" {
 #   name           = "My First Terraform Project"
 # }

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,6 @@ terraform {
 provider "metal" {
   auth_token = var.auth_token
 }
-# Credentials for all Equinix resources
 
 data "metal_project" "project" {
   name = "My Project"
@@ -38,18 +37,8 @@ data "metal_project" "project" {
 
 # If you want to create a fresh project, you can create one with metal_project
 #
-Client ID and Client Secret can be omitted when the only Equinix resources
-consumed are Equinix Metal resources.
-
-```hcl
-# Credentials for only Equinix Metal resources
-provider "equinix" {
-  auth_token    = "someEquinixMetalToken"
-}
-```
-
 # resource "metal_project" "cool_project" {
-#   name           = "My First Terraform Project"
+#   name = "My First Terraform Project"
 # }
 
 # Create a device and add it to tf_project_1

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -9,6 +9,8 @@ description: |-
 
 Use this resource to create Metal Gateway resources in Equinix Metal.
 
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
 ## Example Usage
 
 ```hcl
@@ -53,9 +55,10 @@ resource "metal_gateway" "test" {
 
 * `project_id` - UUID of the project where the gateway is scoped to
 * `vlan_id` - UUID of the VLAN where the gateway is scoped to
-* `ip_reservation_id` - (Optional) UUID of IP reservation block to bind to the gateway, the reservation must be in the same metro as the VLAN, conflicts with `private_ipv4_subnet_size`
+* `ip_reservation_id` - (Optional)  UUID of Public or VRF IP Reservation to associate with the gateway, the reservation must be in the same metro as the VLAN, conflicts with `private_ipv4_subnet_size`
 * `private_ipv4_subnet_size` - (Optional) Size of the private IPv4 subnet to create for this metal gateway, must be one of (8, 16, 32, 64, 128), conflicts with `ip_reservation_id`
 
 ## Attributes Reference
 
 * `state` - Status of the gateway resource
+* `vrf_id` - UUID of the VRF associated with the IP Reservation

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -53,12 +53,12 @@ resource "metal_gateway" "test" {
 
 ## Argument Reference
 
-* `project_id` - UUID of the project where the gateway is scoped to
-* `vlan_id` - UUID of the VLAN where the gateway is scoped to
-* `ip_reservation_id` - (Optional)  UUID of Public or VRF IP Reservation to associate with the gateway, the reservation must be in the same metro as the VLAN, conflicts with `private_ipv4_subnet_size`
-* `private_ipv4_subnet_size` - (Optional) Size of the private IPv4 subnet to create for this metal gateway, must be one of (8, 16, 32, 64, 128), conflicts with `ip_reservation_id`
+* `project_id` - (Required) UUID of the project where the gateway is scoped to.
+* `vlan_id` - (Required) UUID of the VLAN where the gateway is scoped to.
+* `ip_reservation_id` - (Optional) UUID of Public or VRF IP Reservation to associate with the gateway, the reservation must be in the same metro as the VLAN, conflicts with `private_ipv4_subnet_size`.
+* `private_ipv4_subnet_size` - (Optional) Size of the private IPv4 subnet to create for this metal gateway, must be one of (8, 16, 32, 64, 128), conflicts with `ip_reservation_id`.
 
 ## Attributes Reference
 
-* `state` - Status of the gateway resource
-* `vrf_id` - UUID of the VRF associated with the IP Reservation
+* `state` - Status of the gateway resource.
+* `vrf_id` - UUID of the VRF associated with the IP Reservation.

--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -90,7 +90,7 @@ resource "metal_device" "nodes" {
 The following arguments are supported:
 
 * `project_id` - (Required) The metal project ID where to allocate the address block
-* `quantity` - (Required) The number of allocated /32 addresses, a power of 2.
+* `quantity` - (Optional) The number of allocated /32 addresses, a power of 2.
   Required when `type` is not `vrf`.
 * `type` - (Optional) One of `global_ipv4`, `public_ipv4`, or `vrf`. Defaults to
   `public_ipv4` for backward compatibility.
@@ -110,12 +110,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `facility` - The facility where the block was allocated, empty for global blocks
-* `metro` - The metro where the block was allocated, empty for global blocks
-* `project_id` - To which project the addresses beling
-* `quantity` - Number of "/32" addresses in the block
 * `id` - The unique ID of the block
 * `cidr_notation` - Address and mask in CIDR notation, e.g. "147.229.15.30/31"
 * `network` - Network IP address portion of the block specification
@@ -125,11 +121,9 @@ The following attributes are exported:
 * `vrf_id` - VRF ID of the block when type=vrf
 * `public` - boolean flag whether addresses from a block are public
 * `global` - boolean flag whether addresses from a block are global (i.e. can be assigned in any facility)
-* `tags` - string list of tags
 
-Idempotent reference to a first "/32" address from a reserved block might look like this:
-
-`join("/", [cidrhost(metal_reserved_ip_block.myblock.cidr_notation,0), "32"])`
+-> **NOTE:** Idempotent reference to a first `/32` address from a reserved block might look
+like `join("/", [cidrhost(metal_reserved_ip_block.myblock.cidr_notation,0), "32"])`.
 
 ## Import
 

--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -14,11 +14,13 @@ The new device then gets IPv6 and private IPv4 addresses from those block. It al
 Every new device in the project and facility will automatically get IPv6 and private IPv4 addresses from these pre-allocated blocks.
 The IPv6 and private IPv4 blocks can't be created, only imported. With this resource, it's possible to create either public IPv4 blocks or global IPv4 blocks.
 
-Public blocks are allocated in a facility. Addresses from public blocks can only be assigned to devices in the facility. Public blocks can have mask from /24 (256 addresses) to /32 (1 address). If you create public block with this resource, you must fill the facility argmument.
+Public blocks are allocated in a facility. Addresses from public blocks can only be assigned to devices in the facility. Public blocks can have mask from /24 (256 addresses) to /32 (1 address). If you create public block with this resource, you must fill the facility argument.
 
 Addresses from global blocks can be assigned in any facility. Global blocks can have mask from /30 (4 addresses), to /32 (1 address). If you create global block with this resource, you must specify type = "global_ipv4" and you must omit the facility argument.
 
 Once IP block is allocated or imported, an address from it can be assigned to device with the `metal_ip_attachment` resource.
+
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
 
 ## Example Usage
 
@@ -88,14 +90,23 @@ resource "metal_device" "nodes" {
 The following arguments are supported:
 
 * `project_id` - (Required) The metal project ID where to allocate the address block
-* `quantity` - (Required) The number of allocated /32 addresses, a power of 2
-* `type` - (Optional) Either "global_ipv4" or "public_ipv4", defaults to "public_ipv4" for backward compatibility
+* `quantity` - (Required) The number of allocated /32 addresses, a power of 2.
+  Required when `type` is not `vrf`.
+* `type` - (Optional) One of `global_ipv4`, `public_ipv4`, or `vrf`. Defaults to
+  `public_ipv4` for backward compatibility.
 * `facility` - (Optional) Facility where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4, conflicts with `metro`
 * `metro` - (Optional) Metro where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4, conflicts with `facility`
 * `description` - (Optional) Arbitrary description
 * `tags` - (Optional) String list of tags
 * `wait_for_state` - (Optional) Wait for the IP reservation block to reach a desired state on resource creation. One of: `pending`, `created`. The `created` state is default and recommended if the addresses are needed within the configuration. An error will be returned if a timeout or the `denied` state is encountered.
 * `custom_data` - (Optional) Custom Data is an arbitrary object (submitted in Terraform as serialized JSON) to assign to the IP Reservation. This may be helpful for self-managed IPAM. The object must be valid JSON.
+
+* `vrf_id` - (Optional) Only valid and required when `type` is `vrf`. VRF ID for type=vrf reservations.
+* `network` - (Optional) Only valid as an argument and required when `type` is `vrf`. An unreserved network address from an existing `ip_range` in the specified VRF.
+* `cidr` - (Optional) Only valid as an argument and required when `type` is
+  `vrf`. The size of the network to reserve from an existing VRF ip_range.
+  `cidr` can only be specified with `vrf_id`. Range is 22-31. Virtual Circuits
+  require 30-31. Other VRF resources must use a CIDR in the 22-29 range.
 
 ## Attributes Reference
 
@@ -111,6 +122,7 @@ The following attributes are exported:
 * `netmask` - Mask in decimal notation, e.g. "255.255.255.0"
 * `cidr` - length of CIDR prefix of the block as integer
 * `address_family` - Address family as integer (4 or 6)
+* `vrf_id` - VRF ID of the block when type=vrf
 * `public` - boolean flag whether addresses from a block are public
 * `global` - boolean flag whether addresses from a block are global (i.e. can be assigned in any facility)
 * `tags` - string list of tags

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -43,11 +43,9 @@ can be read using the file interpolation function
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID of the key
-* `name` - The name of the SSH key
-* `public_key` - The text of the public key
 * `fingerprint` - The fingerprint of the SSH key
 * `owner_id` - The UUID of the Equinix Metal API User who owns this key
 * `created` - The timestamp for when the SSH key was created

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -25,7 +25,7 @@ resource "metal_ssh_key" "key1" {
 resource "metal_device" "test" {
   hostname         = "test-device"
   plan             = "c3.small.x86"
-  facilities       = ["sjc1"]
+  metro            = "sv"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id

--- a/docs/resources/virtual_circuit.md
+++ b/docs/resources/virtual_circuit.md
@@ -41,6 +41,8 @@ resource "metal_virtual_circuit" "test" {
 
 ## Argument Reference
 
+The following arguments are supported:
+
 * `connection_id` - (Required) UUID of Connection where the VC is scoped to
 * `project_id` - (Required) UUID of the Project where the VC is scoped to
 * `port_id` - (Required) UUID of the Connection Port where the VC is scoped to
@@ -51,22 +53,24 @@ resource "metal_virtual_circuit" "test" {
 * `description` - (Optional) Description for the Virtual Circuit resource
 * `tags` - (Optional) Tags for the Virtual Circuit resource
 * `speed` - (Optional) Speed of the Virtual Circuit resource
-
-## Attributes Reference
-
-* `vrf_id` - (Optional) UUID of the VLAN to associate.
+* `vrf_id` - (Optional) UUID of the VRF to associate.
 * `peer_asn` - (Optional, required with `vrf_id`) The BGP ASN of the peer. The same ASN may be the used across several VCs, but it cannot be the same as the local_asn of the VRF.
 * `subnet` - (Optional, required with `vrf_id`) A subnet from one of the IP
   blocks associated with the VRF that we will help create an IP reservation for. Can only be either a /30 or /31.
   * For a /31 block, it will only have two IP addresses, which will be used for
   the metal_ip and customer_ip.
   * For a /30 block, it will have four IP addresses, but the first and last IP addresses are not usable. We will default to the first usable IP address for the metal_ip.
-* `metal_ip` - (Optional, required with `vrf_id`) The IP address that’s set as “our” IP that is configured on the rack_local_vlan SVI. Will default to the first usable IP in the subnet.
+* `metal_ip` - (Optional, required with `vrf_id`) The IP address that’s set as “our” IP that is configured on the rack_local_vlan SVI (Switch Virtual Interface). Will default to the first usable IP in the subnet.
 * `customer_ip` - (Optional, required with `vrf_id`) The IP address set as the customer IP which the CSR switch will peer with. Will default to the other usable IP in the subnet.
 * `md5` - (Optional, only valid with `vrf_id`) The password that can be set for the VRF BGP peer
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
 * `status` - Status of the virtal circuit
-* `vnid`
-* `nni_nvid` - VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/)
+* `vnid` - VNID VLAN parameter, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/).
+* `nni_vnid` - VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/)
 
 ## Import
 

--- a/docs/resources/virtual_circuit.md
+++ b/docs/resources/virtual_circuit.md
@@ -9,6 +9,8 @@ description: |-
 
 Use this resource to associate VLAN with a Dedicated Port from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/#associating-a-vlan-with-a-dedicated-port).
 
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
 ## Example Usage
 
 Pick an existing Project and Connection, create a VLAN and use `metal_virtual_circuit` to associate it with a Primary Port of the Connection.
@@ -52,6 +54,24 @@ resource "metal_virtual_circuit" "test" {
 
 ## Attributes Reference
 
+* `vrf_id` - (Optional) UUID of the VLAN to associate.
+* `peer_asn` - (Optional, required with `vrf_id`) The BGP ASN of the peer. The same ASN may be the used across several VCs, but it cannot be the same as the local_asn of the VRF.
+* `subnet` - (Optional, required with `vrf_id`) A subnet from one of the IP
+  blocks associated with the VRF that we will help create an IP reservation for. Can only be either a /30 or /31.
+  * For a /31 block, it will only have two IP addresses, which will be used for
+  the metal_ip and customer_ip.
+  * For a /30 block, it will have four IP addresses, but the first and last IP addresses are not usable. We will default to the first usable IP address for the metal_ip.
+* `metal_ip` - (Optional, required with `vrf_id`) The IP address that’s set as “our” IP that is configured on the rack_local_vlan SVI. Will default to the first usable IP in the subnet.
+* `customer_ip` - (Optional, required with `vrf_id`) The IP address set as the customer IP which the CSR switch will peer with. Will default to the other usable IP in the subnet.
+* `md5` - (Optional, only valid with `vrf_id`) The password that can be set for the VRF BGP peer
 * `status` - Status of the virtal circuit
 * `vnid`
 * `nni_nvid` - VLAN parameters, see the [documentation for Equinix Fabric](https://metal.equinix.com/developers/docs/networking/fabric/)
+
+## Import
+
+This resource can be imported using an existing Virtual Circuit ID:
+
+```sh
+terraform import metal_virtual_circuit {existing_id}
+```

--- a/docs/resources/vrf.md
+++ b/docs/resources/vrf.md
@@ -1,0 +1,103 @@
+---
+page_title: "Equinix Metal: metal_vrf"
+subcategory: ""
+description: |-
+  (not-GA) Provides a resource for Equinix Metal VRF.
+---
+
+# metal_vrf (Resource)
+
+Use this resource to manage a VRF.
+
+~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.
+
+## Example Usage
+
+Create a VRF in your desired metro and project with any IP ranges that you want the VRF to route and forward.
+
+```hcl
+resource "metal_project" "example" {
+    name = "example"
+}
+
+resource "metal_vrf" "example" {
+    description = "VRF with ASN 65000 and a pool of address space that includes 192.168.100.0/25"
+    name = "example-vrf"
+    metro = "da"
+    local_asn = "65000"
+    ip_ranges = ["192.168.100.0/25", "192.168.200.0/25"]
+    project_id = metal_project.example.id
+}
+```
+
+Create IP reservations and assign them to a Metal Gateway resources. The Gateway will be assigned the first address in the block.
+
+```hcl
+resource "metal_reserved_ip_block" "example" {
+    description = "Reserved IP block (192.168.100.0/29) taken from on of the ranges in the VRF's pool of address space."
+    project_id = metal_project.example.id
+    metro = metal_vrf.example.metro
+    type = "vrf"
+    vrf_id = metal_vrf.example.id
+    cidr = 29
+    network = "192.168.100.0"
+}
+
+resource "metal_vlan" "example" {
+ description = "A VLAN for Layer2 and Hybrid Metal devices"
+ metro       = metal_vrf.example.metro
+ project_id  = metal_project.example.id
+}
+
+resource "metal_gateway" "example" {
+    description       = "A Gateway on the VRF192.168.100.0/29
+    project_id        = metal_project.example.id
+    vlan_id           = metal_vlan.example.id
+    ip_reservation_id = metal_reserved_ip_block.example.id
+}
+```
+
+Attach a Virtual Circuit from a Dedicated Metal Connection to the Metal Gateway.
+
+```hcl
+data "metal_connection" "example" {
+    connection_id = var.metal_dedicated_connection_id
+}
+
+resource "metal_virtual_circuit" "example" {
+    name = "example-vc"
+    description = "Virtual Circuit"
+    connection_id = data.metal_connection.example.id
+    project_id = metal_project.example.id
+    port_id = data.metal_connection.example.ports[0].id
+    nni_vlan = 1024
+    vrf_id = metal_vrf.example.id
+    peer_asn = 65530
+    subnet = "192.168.100.16/31"
+    metal_ip = "192.168.100.16"
+    customer_ip = "192.168.100.17"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) User-supplied name of the VRF, unique to the project
+* `metro` - (Required) Metro ID or Code where the VRF will be deployed.
+* `project_id` - (Required) Project ID where the VRF will be deployed.
+* `description` - (Optional) Description of the VRF.
+* `local_asn` - (Optional) The 4-byte ASN set on the VRF.
+* `ip_ranges` - (Optional) All IPv4 and IPv6 Ranges that will be available to BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must not overlap other ranges within the VRF.
+
+## Attributes Reference
+
+No additional attributes are exported.
+
+## Import
+
+This resource can be imported using an existing VRF ID:
+
+```sh
+terraform import metal_vrf {existing_id}
+```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.22.0
+	github.com/packethost/packngo v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.22.0 h1:7syZ1jDN5rbdkkrh9A5rA/ijXe0AHNovNqlUUf0L+uM=
-github.com/packethost/packngo v0.22.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.23.0 h1:AnG26Th7v68solhArM/sF/mCB8hV2LI70VYxebF4bgE=
+github.com/packethost/packngo v0.23.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/metal/datasource_metal_device_test.go
+++ b/metal/datasource_metal_device_test.go
@@ -45,8 +45,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -95,8 +95,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"

--- a/metal/datasource_metal_device_test.go
+++ b/metal/datasource_metal_device_test.go
@@ -45,8 +45,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -95,8 +95,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -14,7 +14,7 @@ var (
 )
 
 func TestAccDataSourceFacility_Basic(t *testing.T) {
-	testFac := "ewr1"
+	testFac := "da11"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -62,7 +62,7 @@ func TestAccDataSourceFacility_Features(t *testing.T) {
 func testAccDataSourceFacilityConfigFeatures() string {
 	return `
 data "metal_facility" "test" {
-    code = "ewr1"
+    code = "da11"
     features_required = ["baremetal", "ibx"]
 }
 `

--- a/metal/datasource_metal_facility_test.go
+++ b/metal/datasource_metal_facility_test.go
@@ -14,7 +14,7 @@ var (
 )
 
 func TestAccDataSourceFacility_Basic(t *testing.T) {
-	testFac := "dc13"
+	testFac := "ewr1"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -62,7 +62,7 @@ func TestAccDataSourceFacility_Features(t *testing.T) {
 func testAccDataSourceFacilityConfigFeatures() string {
 	return `
 data "metal_facility" "test" {
-    code = "ny5"
+    code = "ewr1"
     features_required = ["baremetal", "ibx"]
 }
 `

--- a/metal/datasource_metal_gateway.go
+++ b/metal/datasource_metal_gateway.go
@@ -27,6 +27,11 @@ func dataSourceMetalGateway() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "UUID of the VLAN to associate",
 			},
+			"vrf_id": {
+				Computed:    true,
+				Type:        schema.TypeString,
+				Description: "UUID of the VRF associated with the IP Reservation",
+			},
 			"ip_reservation_id": {
 				Computed:    true,
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_gateway.go
+++ b/metal/datasource_metal_gateway.go
@@ -7,7 +7,6 @@ import (
 )
 
 func dataSourceMetalGateway() *schema.Resource {
-
 	return &schema.Resource{
 		Read: dataSourceMetalGatewayRead,
 

--- a/metal/datasource_metal_ip_block_ranges_test.go
+++ b/metal/datasource_metal_ip_block_ranges_test.go
@@ -44,15 +44,15 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-test"
-  plan             = "c1.small.x86"
-  facilities       = ["ny5"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
 }
 
 data "metal_ip_block_ranges" "test" {
-    facility         = "ny5"
+    facility         = "ewr1"
     project_id       = metal_device.test.project_id
 }
 

--- a/metal/datasource_metal_ip_block_ranges_test.go
+++ b/metal/datasource_metal_ip_block_ranges_test.go
@@ -44,15 +44,15 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-test"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
 }
 
 data "metal_ip_block_ranges" "test" {
-    facility         = "ewr1"
+    facility         = "da11"
     project_id       = metal_device.test.project_id
 }
 

--- a/metal/datasource_metal_port_test.go
+++ b/metal/datasource_metal_port_test.go
@@ -36,8 +36,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-port"
-  plan             = "c3.medium.x86"
-  metro            = "sv"
+  plan             = "c2.medium.x86"
+  metro            = "ny"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -79,8 +79,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-port"
-  plan             = "c3.medium.x86"
-  metro            = "sv"
+  plan             = "c2.medium.x86"
+  metro            = "ny"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id

--- a/metal/datasource_metal_port_test.go
+++ b/metal/datasource_metal_port_test.go
@@ -36,8 +36,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-port"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -79,8 +79,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-port"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_20_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id

--- a/metal/datasource_metal_precreated_ip_block.go
+++ b/metal/datasource_metal_precreated_ip_block.go
@@ -68,7 +68,10 @@ func dataSourceMetalPreCreatedIPBlock() *schema.Resource {
 func dataSourceMetalPreCreatedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 	projectID := d.Get("project_id").(string)
-	ips, _, err := client.ProjectIPs.List(projectID, nil)
+	getOpts := packngo.GetOptions{Includes: []string{"facility", "metro", "project", "vrf"}}
+	getOpts.Filter("types", "public_ipv4,global_ipv4,private_ipv4,public_ipv6,vrf")
+
+	ips, _, err := client.ProjectIPs.List(projectID, &getOpts)
 	if err != nil {
 		return err
 	}
@@ -115,8 +118,6 @@ func dataSourceMetalPreCreatedIPBlockRead(d *schema.ResourceData, meta interface
 				return loadBlock(d, &ip)
 			}
 		}
-
 	}
 	return fmt.Errorf("Could not find matching reserved block, all IPs were %v", ips)
-
 }

--- a/metal/datasource_metal_precreated_ip_block_test.go
+++ b/metal/datasource_metal_precreated_ip_block_test.go
@@ -44,7 +44,7 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-ip-blockt"
-  plan             = "c3.small.x86"
+  plan             = "c2.medium.x86"
   metro            = "ny"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/metal/datasource_metal_precreated_ip_block_test.go
+++ b/metal/datasource_metal_precreated_ip_block_test.go
@@ -44,8 +44,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-ip-blockt"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id

--- a/metal/datasource_metal_reserved_ip_block.go
+++ b/metal/datasource_metal_reserved_ip_block.go
@@ -125,7 +125,7 @@ func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}
 	getOpts.Filter("types", "public_ipv4,global_ipv4,private_ipv4,public_ipv6,vrf")
 
 	if !(blockIdOk || (projectIdOk && addressOk)) {
-		return fmt.Errorf("You must specify either id or project_id and ip_address")
+		return fmt.Errorf("you must specify either id or project_id and ip_address")
 	}
 	if blockIdOk {
 		block, _, err := client.ProjectIPs.Get(
@@ -158,7 +158,7 @@ func dataSourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}
 			return loadBlock(d, &b)
 		}
 	}
-	return fmt.Errorf("Could not find matching reserved block, all blocks were \n%s", listOfCidrs(blocks))
+	return fmt.Errorf("could not find matching reserved block, all blocks were \n%s", listOfCidrs(blocks))
 
 }
 
@@ -168,5 +168,4 @@ func listOfCidrs(blocks []packngo.IPAddressReservation) string {
 		cidrs = append(cidrs, fmt.Sprintf("%s/%d", b.Network, b.CIDR))
 	}
 	return strings.Join(cidrs, "\n")
-
 }

--- a/metal/datasource_metal_spot_market_price_test.go
+++ b/metal/datasource_metal_spot_market_price_test.go
@@ -29,13 +29,13 @@ func TestAccDataSourceMetalSpotPrice_Basic(t *testing.T) {
 func testDataSourceMetalSpotMarketPrice() string {
 	return fmt.Sprintf(`
 data "metal_spot_market_price" "metro" {
-	metro = "sv"
-	plan     = "c3.medium.x86"
+	metro = "ny"
+	plan     = "c2.medium.x86"
 }
 
 data "metal_spot_market_price" "facility" {
-	facility = "sv15"
-	plan     = "c3.medium.x86"
+	facility = "ewr1"
+	plan     = "c2.medium.x86"
 }
 `)
 }

--- a/metal/datasource_metal_spot_market_price_test.go
+++ b/metal/datasource_metal_spot_market_price_test.go
@@ -29,13 +29,13 @@ func TestAccDataSourceMetalSpotPrice_Basic(t *testing.T) {
 func testDataSourceMetalSpotMarketPrice() string {
 	return fmt.Sprintf(`
 data "metal_spot_market_price" "metro" {
-	metro = "ny"
-	plan     = "c2.medium.x86"
+	metro    = "da"
+	plan     = "c3.medium.x86"
 }
 
 data "metal_spot_market_price" "facility" {
-	facility = "ewr1"
-	plan     = "c2.medium.x86"
+	facility = "da11"
+	plan     = "c3.medium.x86"
 }
 `)
 }

--- a/metal/datasource_metal_spot_market_request_test.go
+++ b/metal/datasource_metal_spot_market_request_test.go
@@ -58,7 +58,7 @@ resource "metal_project" "test" {
 resource "metal_spot_market_request" "req" {
   project_id    = "${metal_project.test.id}"
   max_bid_price = 0.01
-  facilities    = ["sv15"]
+  facilities    = ["ewr1"]
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -67,7 +67,7 @@ resource "metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c3.small.x86"
+    plan             = "c2.medium.x86"
   }
 }
 
@@ -87,7 +87,7 @@ resource "metal_project" "test" {
 resource "metal_spot_market_request" "req" {
   project_id    = "${metal_project.test.id}"
   max_bid_price = 0.01
-  metro = "sv"
+  metro = "ny"
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -96,7 +96,7 @@ resource "metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c3.small.x86"
+    plan             = "c2.medium.x86"
   }
 }
 

--- a/metal/datasource_metal_spot_market_request_test.go
+++ b/metal/datasource_metal_spot_market_request_test.go
@@ -58,7 +58,7 @@ resource "metal_project" "test" {
 resource "metal_spot_market_request" "req" {
   project_id    = "${metal_project.test.id}"
   max_bid_price = 0.01
-  facilities    = ["ewr1"]
+  facilities    = ["da11"]
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -67,7 +67,7 @@ resource "metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c2.medium.x86"
+    plan             = "c3.medium.x86"
   }
 }
 
@@ -87,7 +87,7 @@ resource "metal_project" "test" {
 resource "metal_spot_market_request" "req" {
   project_id    = "${metal_project.test.id}"
   max_bid_price = 0.01
-  metro = "ny"
+  metro = "da"
   devices_min   = 1
   devices_max   = 1
   wait_for_devices = false
@@ -96,7 +96,7 @@ resource "metal_spot_market_request" "req" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c2.medium.x86"
+    plan             = "c3.medium.x86"
   }
 }
 

--- a/metal/datasource_metal_vlan.go
+++ b/metal/datasource_metal_vlan.go
@@ -104,6 +104,9 @@ func dataSourceMetalVlanRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		vlan, err = matchingVlan(vlans.VirtualNetworks, vxlan, projectID, facility, metro)
+		if err != nil {
+			return friendlyError(err)
+		}
 	}
 
 	assignedDevices := []string{}

--- a/metal/datasource_metal_vrf.go
+++ b/metal/datasource_metal_vrf.go
@@ -1,0 +1,57 @@
+package metal
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceMetalVRF() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceMetalVRFRead,
+
+		Schema: map[string]*schema.Schema{
+			"vrf_id": {
+				Required:    true,
+				Type:        schema.TypeString,
+				Description: "ID of the VRF to lookup",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "User-supplied name of the VRF, unique to the project",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of the VRF",
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Metro Code",
+			},
+			"local_asn": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The 4-byte ASN set on the VRF.",
+			},
+			"ip_ranges": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "All IPv4 and IPv6 Ranges that will be available to BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must not overlap other ranges within the VRF.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Project ID",
+			},
+		},
+	}
+}
+
+func dataSourceMetalVRFRead(d *schema.ResourceData, meta interface{}) error {
+	vrfId, _ := d.Get("vrf_id").(string)
+
+	d.SetId(vrfId)
+	return resourceMetalVRFRead(d, meta)
+}

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -1,6 +1,7 @@
 package metal
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -59,6 +60,7 @@ func Provider() *schema.Provider {
 			"metal_volume":               dataSourceMetalVolume(),
 			"metal_virtual_circuit":      dataSourceMetalVirtualCircuit(),
 			"metal_vlan":                 dataSourceMetalVlan(),
+			"metal_vrf":                  dataSourceMetalVRF(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -79,6 +81,7 @@ func Provider() *schema.Provider {
 			"metal_spot_market_request":  resourceMetalSpotMarketRequest(),
 			"metal_vlan":                 resourceMetalVlan(),
 			"metal_virtual_circuit":      resourceMetalVirtualCircuit(),
+			"metal_vrf":                  resourceMetalVRF(),
 			"metal_bgp_session":          resourceMetalBGPSession(),
 			"metal_port_vlan_attachment": resourceMetalPortVlanAttachment(),
 			"metal_gateway":              resourceMetalGateway(),
@@ -106,6 +109,19 @@ func providerConfigure(tfVersion string) func(d *schema.ResourceData) (interface
 		}
 		return config.Client(), nil
 	}
+}
+
+func expandListToStringList(list []interface{}) []string {
+	result := make([]string, len(list))
+	for i, v := range list {
+		result[i] = fmt.Sprint(v)
+	}
+	return result
+}
+
+func expandSetToStringList(set *schema.Set) []string {
+	list := set.List()
+	return expandListToStringList(list)
 }
 
 var resourceDefaultTimeouts = &schema.ResourceTimeout{

--- a/metal/resource_metal_bgp_setup_test.go
+++ b/metal/resource_metal_bgp_setup_test.go
@@ -77,8 +77,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
     hostname         = "tfacc-test-bgp-sesh"
-    plan             = "c2.medium.x86"
-    facilities       = ["ewr1", "ny7", "any"]
+    plan             = "c3.medium.x86"
+    facilities       = ["da11", "ny7", "any"]
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${metal_project.test.id}"

--- a/metal/resource_metal_bgp_setup_test.go
+++ b/metal/resource_metal_bgp_setup_test.go
@@ -77,8 +77,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
     hostname         = "tfacc-test-bgp-sesh"
-    plan             = "c1.small.x86"
-    facilities       = ["ny5", "ny7", "any"]
+    plan             = "c2.medium.x86"
+    facilities       = ["ewr1", "ny7", "any"]
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${metal_project.test.id}"

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -18,7 +18,6 @@ func TestSpeedConversion(t *testing.T) {
 	speedUint, err := speedStrToUint("50Mbps")
 	if err != nil {
 		t.Errorf("Error converting speed string to uint64: %s", err)
-
 	}
 	if speedUint != 50*mega {
 		t.Errorf("Speed string conversion failed. Expected: %d, got: %d", 50*mega, speedUint)
@@ -77,7 +76,6 @@ func testAccMetalConnectionConfig_Shared(randstr string) string {
 }
 
 func TestAccMetalConnection_Shared(t *testing.T) {
-
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -150,7 +148,6 @@ func testDataSourceMetalConnectionConfig() string {
 }
 
 func TestAccMetalConnection_Dedicated(t *testing.T) {
-
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -207,7 +204,6 @@ func testAccMetalConnectionConfig_Tunnel(randstr string) string {
 }
 
 func TestAccMetalConnection_Tunnel(t *testing.T) {
-
 	rs := acctest.RandString(10)
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -166,7 +166,7 @@ func TestAccMetalDevice_Metro(t *testing.T) {
 					testAccCheckMetalDeviceNetwork(r),
 					testAccCheckMetalDeviceAttributes(&device),
 					resource.TestCheckResourceAttr(
-						r, "metro", "ny"),
+						r, "metro", "da"),
 				),
 			},
 		},
@@ -478,8 +478,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -496,8 +496,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -521,8 +521,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -540,8 +540,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -560,8 +560,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -575,8 +575,8 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   project_id       = "${metal_project.test.id}"
 }`, projSuffix)
@@ -590,8 +590,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -607,8 +607,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test"  {
 
   hostname         = "tfacc-device-test-ipxe-script-url"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1", "any"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11", "any"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -624,8 +624,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test_ipxe_script_url"  {
 
   hostname         = "tfacc-device-test-ipxe-script-url"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "custom_ipxe"
   user_data        = "#!/bin/sh\ntouch /tmp/test"
   billing_cycle    = "hourly"
@@ -642,8 +642,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test_ipxe_conflict" {
   hostname         = "tfacc-device-test-ipxe-conflict"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "custom_ipxe"
   user_data        = "#!ipxe\nset conflict ipxe_script_url"
   billing_cycle    = "hourly"
@@ -659,8 +659,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test_ipxe_missing" {
   hostname         = "tfacc-device-test-ipxe-missing"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -166,7 +166,7 @@ func TestAccMetalDevice_Metro(t *testing.T) {
 					testAccCheckMetalDeviceNetwork(r),
 					testAccCheckMetalDeviceAttributes(&device),
 					resource.TestCheckResourceAttr(
-						r, "metro", "sv"),
+						r, "metro", "ny"),
 				),
 			},
 		},
@@ -478,8 +478,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -496,8 +496,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -521,8 +521,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -540,8 +540,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -560,8 +560,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c3.small.x86"
-  metro            = "sv"
+  plan             = "c2.medium.x86"
+  metro            = "ny"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -575,8 +575,8 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   project_id       = "${metal_project.test.id}"
 }`, projSuffix)
@@ -590,8 +590,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-test-device"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -607,8 +607,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test"  {
 
   hostname         = "tfacc-device-test-ipxe-script-url"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15", "any"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1", "any"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -624,8 +624,8 @@ resource "metal_project" "test" {
 resource "metal_device" "test_ipxe_script_url"  {
 
   hostname         = "tfacc-device-test-ipxe-script-url"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "custom_ipxe"
   user_data        = "#!/bin/sh\ntouch /tmp/test"
   billing_cycle    = "hourly"
@@ -642,8 +642,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test_ipxe_conflict" {
   hostname         = "tfacc-device-test-ipxe-conflict"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "custom_ipxe"
   user_data        = "#!ipxe\nset conflict ipxe_script_url"
   billing_cycle    = "hourly"
@@ -659,8 +659,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test_ipxe_missing" {
   hostname         = "tfacc-device-test-ipxe-missing"
-  plan             = "c1.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"

--- a/metal/resource_metal_gateway.go
+++ b/metal/resource_metal_gateway.go
@@ -51,10 +51,15 @@ func resourceMetalGateway() *schema.Resource {
 				Description: "UUID of the VLAN to associate",
 				ForceNew:    true,
 			},
+			"vrf_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of the VRF associated with the IP Reservation",
+			},
 			"ip_reservation_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Description:   "UUID of the IP Reservation to associate, must be in the same metro as the VLAN",
+				Description:   "UUID of the Public or VRF IP Reservation to associate, must be in the same metro as the VLAN",
 				ConflictsWith: []string{"private_ipv4_subnet_size"},
 				ForceNew:      true,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -72,10 +77,12 @@ func resourceMetalGateway() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				Description:   fmt.Sprintf("Size of the private IPv4 subnet to create for this gateway, one of %v", subnetSizes),
-				ConflictsWith: []string{"ip_reservation_id"},
+				ConflictsWith: []string{"ip_reservation_id", "vrf_id"},
 				ValidateFunc:  intInSlice(subnetSizes),
+				Computed:      true,
 				ForceNew:      true,
 			},
+
 			"state": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -115,7 +122,8 @@ func resourceMetalGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 	mgId := d.Id()
 
-	includes := &packngo.GetOptions{Includes: []string{"project", "ip_reservation", "virtual_network"}}
+	includes := &packngo.GetOptions{Includes: []string{"project", "ip_reservation", "virtual_network", "vrf"}}
+
 	mg, _, err := client.MetalGateways.Get(mgId, includes)
 	if err != nil {
 		return err
@@ -133,6 +141,12 @@ func resourceMetalGatewayRead(d *schema.ResourceData, meta interface{}) error {
 		"ip_reservation_id":        mg.IPReservation.ID,
 		"private_ipv4_subnet_size": int(privateIPv4SubnetSize),
 		"state":                    mg.State,
+		"vrf_id": func(d *schema.ResourceData, k string) error {
+			if mg.VRF == nil {
+				return nil
+			}
+			return d.Set(k, mg.VRF.ID)
+		},
 	})
 }
 

--- a/metal/resource_metal_ip_attachment_test.go
+++ b/metal/resource_metal_ip_attachment_test.go
@@ -61,8 +61,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-attachment-test"
-  plan             = "c2.medium.x86"
-  facilities       = ["ewr1"]
+  plan             = "c3.medium.x86"
+  facilities       = ["da11"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -70,7 +70,7 @@ resource "metal_device" "test" {
 
 resource "metal_reserved_ip_block" "test" {
     project_id = metal_project.test.id
-    facility = "ewr1"
+    facility = "da11"
 	quantity = 2
 }
 
@@ -117,8 +117,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-attachment-test"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -126,8 +126,8 @@ resource "metal_device" "test" {
 
 resource "metal_reserved_ip_block" "test" {
     project_id = metal_project.test.id
-    metro      = "ny"
-	quantity = 2
+    metro      = "da"
+	quantity   = 2
 }
 
 

--- a/metal/resource_metal_ip_attachment_test.go
+++ b/metal/resource_metal_ip_attachment_test.go
@@ -61,8 +61,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-attachment-test"
-  plan             = "c3.small.x86"
-  facilities       = ["sv15"]
+  plan             = "c2.medium.x86"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -70,7 +70,7 @@ resource "metal_device" "test" {
 
 resource "metal_reserved_ip_block" "test" {
     project_id = metal_project.test.id
-    facility = "sv15"
+    facility = "ewr1"
 	quantity = 2
 }
 
@@ -117,8 +117,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-device-ip-attachment-test"
-  plan             = "c3.medium.x86"
-  metro            = "sv"
+  plan             = "c2.medium.x86"
+  metro            = "ny"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = metal_project.test.id
@@ -126,7 +126,7 @@ resource "metal_device" "test" {
 
 resource "metal_reserved_ip_block" "test" {
     project_id = metal_project.test.id
-    metro      = "sv"
+    metro      = "ny"
 	quantity = 2
 }
 

--- a/metal/resource_metal_port_test.go
+++ b/metal/resource_metal_port_test.go
@@ -19,8 +19,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-metal-port-test"
-  plan             = "c2.medium.x86"
-  metro            = "ny"
+  plan             = "c3.medium.x86"
+  metro            = "da"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"

--- a/metal/resource_metal_port_test.go
+++ b/metal/resource_metal_port_test.go
@@ -19,8 +19,8 @@ resource "metal_project" "test" {
 
 resource "metal_device" "test" {
   hostname         = "tfacc-metal-port-test"
-  plan             = "c3.small.x86"
-  metro            = "sv"
+  plan             = "c2.medium.x86"
+  metro            = "ny"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${metal_project.test.id}"
@@ -119,7 +119,7 @@ resource "metal_port" "bond0" {
 
 resource "metal_vlan" "test" {
   description = "test"
-  metro = "sv"
+  metro = "ny"
   project_id = metal_project.test.id
 }
 `, confAccMetalPort_base(name))
@@ -139,14 +139,14 @@ resource "metal_port" "bond0" {
 
 resource "metal_vlan" "test1" {
   description = "test1"
-  metro = "sv"
+  metro = "ny"
   project_id = metal_project.test.id
   vxlan = 1001
 }
 
 resource "metal_vlan" "test2" {
   description = "test2"
-  metro = "sv"
+  metro = "ny"
   project_id = metal_project.test.id
   vxlan = 1002
 }

--- a/metal/resource_metal_project_test.go
+++ b/metal/resource_metal_project_test.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	resource.AddTestSweepers("metal_project", &resource.Sweeper{
 		Name:         "metal_project",
-		Dependencies: []string{"metal_device"},
+		Dependencies: []string{"metal_vlan"},
 		F:            testSweepProjects,
 	})
 }
@@ -73,14 +73,15 @@ func TestAccMetalProject_Basic(t *testing.T) {
 }
 
 type mockProjectService struct {
-	CreateFn          func(project *packngo.ProjectCreateRequest) (*packngo.Project, *packngo.Response, error)
-	UpdateFn          func(projectID string, project *packngo.ProjectUpdateRequest) (*packngo.Project, *packngo.Response, error)
-	ListFn            func(project *packngo.ListOptions) ([]packngo.Project, *packngo.Response, error)
-	DeleteFn          func(projectID string) (*packngo.Response, error)
-	GetFn             func(projectID string, opts *packngo.GetOptions) (*packngo.Project, *packngo.Response, error)
-	ListBGPSessionsFn func(projectID string, opts *packngo.ListOptions) ([]packngo.BGPSession, *packngo.Response, error)
-	ListEventsFn      func(projectID string, opts *packngo.ListOptions) ([]packngo.Event, *packngo.Response, error)
-	ListSSHKeysFn     func(projectID string, opts *packngo.ListOptions) ([]packngo.SSHKey, *packngo.Response, error)
+	CreateFn              func(project *packngo.ProjectCreateRequest) (*packngo.Project, *packngo.Response, error)
+	UpdateFn              func(projectID string, project *packngo.ProjectUpdateRequest) (*packngo.Project, *packngo.Response, error)
+	ListFn                func(project *packngo.ListOptions) ([]packngo.Project, *packngo.Response, error)
+	DeleteFn              func(projectID string) (*packngo.Response, error)
+	GetFn                 func(projectID string, opts *packngo.GetOptions) (*packngo.Project, *packngo.Response, error)
+	ListBGPSessionsFn     func(projectID string, opts *packngo.ListOptions) ([]packngo.BGPSession, *packngo.Response, error)
+	ListEventsFn          func(projectID string, opts *packngo.ListOptions) ([]packngo.Event, *packngo.Response, error)
+	ListSSHKeysFn         func(projectID string, opts *packngo.ListOptions) ([]packngo.SSHKey, *packngo.Response, error)
+	DiscoverBGPSessionsFn func(projectID string, opts *packngo.GetOptions) ([]packngo.BGPDiscoverResponse, *packngo.Response, error)
 }
 
 func (m *mockProjectService) Create(project *packngo.ProjectCreateRequest) (*packngo.Project, *packngo.Response, error) {
@@ -112,6 +113,10 @@ func (m *mockProjectService) ListSSHKeys(projectID string, opts *packngo.ListOpt
 
 func (m *mockProjectService) ListEvents(projectID string, opts *packngo.ListOptions) ([]packngo.Event, *packngo.Response, error) {
 	return m.ListEventsFn(projectID, opts)
+}
+
+func (m *mockProjectService) DiscoverBGPSessions(projectID string, opts *packngo.ListOptions) (*packngo.BGPDiscoverResponse, *packngo.Response, error) {
+	return m.DiscoverBGPSessions(projectID, opts)
 }
 
 var _ packngo.ProjectService = (*mockProjectService)(nil)

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -57,6 +57,10 @@ func metalIPComputedFields() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
+		"vrf_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	}
 }
 
@@ -133,18 +137,20 @@ func resourceMetalReservedIPBlock() *schema.Resource {
 		Description: "Arbitrary description",
 	}
 	reservedBlockSchema["quantity"] = &schema.Schema{
-		Type:        schema.TypeInt,
-		Required:    true,
-		ForceNew:    true,
-		Description: "The number of allocated /32 addresses, a power of 2",
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ForceNew:     true,
+		Computed:     true,
+		ExactlyOneOf: []string{"vrf_id", "quantity"},
+		Description:  "The number of allocated /32 addresses, a power of 2",
 	}
 	reservedBlockSchema["type"] = &schema.Schema{
 		Type:         schema.TypeString,
 		ForceNew:     true,
 		Default:      "public_ipv4",
 		Optional:     true,
-		Description:  "Either global_ipv4 or public_ipv4, defaults to public_ipv4 for backward compatibility",
-		ValidateFunc: validation.StringInSlice([]string{"public_ipv4", "global_ipv4"}, false),
+		Description:  "Either global_ipv4, public_ipv4, or vrf. Defaults to public_ipv4.",
+		ValidateFunc: validation.StringInSlice([]string{"public_ipv4", "global_ipv4", "vrf"}, false),
 	}
 	reservedBlockSchema["cidr_notation"] = &schema.Schema{
 		Type:     schema.TypeString,
@@ -184,6 +190,31 @@ func resourceMetalReservedIPBlock() *schema.Resource {
 		),
 	}
 
+	reservedBlockSchema["vrf_id"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		ForceNew:     true,
+		ExactlyOneOf: []string{"vrf_id", "quantity"},
+		Description:  "VRF ID for type=vrf reservations",
+	}
+	reservedBlockSchema["network"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Optional:     true,
+		RequiredWith: []string{"vrf_id"},
+		ForceNew:     true,
+		Computed:     true,
+		Description:  "an unreserved network address from an existing vrf ip_range. `network` can only be specified with vrf_id",
+	}
+	reservedBlockSchema["cidr"] = &schema.Schema{
+		Type:         schema.TypeInt,
+		Optional:     true,
+		RequiredWith: []string{"vrf_id"},
+		ForceNew:     true,
+		Computed:     true,
+		Description:  "the size of the network to reserve from an existing vrf ip_range. `cidr` can only be specified with `vrf_id`. Minimum range is 22-29, with 30-31 supported and necessary for virtual-circuits",
+	}
+	// TODO: add comments field, used for reservations that are not automatically approved
+
 	return &schema.Resource{
 		Create: resourceMetalReservedIPBlockCreate,
 		Read:   resourceMetalReservedIPBlockRead,
@@ -206,18 +237,19 @@ func resourceMetalReservedIPBlockCreate(d *schema.ResourceData, meta interface{}
 	typ := d.Get("type").(string)
 
 	req := packngo.IPReservationRequest{
-		Type:     typ,
+		Type:     packngo.IPReservationType(typ),
 		Quantity: quantity,
 	}
 	facility, facOk := d.GetOk("facility")
 	metro, metOk := d.GetOk("metro")
 
 	// no need to guard facOk && metOk, they "ConflictsWith" each-other
-	if typ == "global_ipv4" {
+	switch typ {
+	case "global_ipv4":
 		if facOk || metOk {
 			return fmt.Errorf("facility and metro can't be set for global IP block reservation")
 		}
-	} else {
+	case "public_ipv4":
 		if !(facOk || metOk) {
 			return fmt.Errorf("You should set either metro or facility for non-global IP block reservation")
 		}
@@ -248,7 +280,11 @@ func resourceMetalReservedIPBlockCreate(d *schema.ResourceData, meta interface{}
 		req.CustomData = d.Get("custom_data")
 	}
 
-	blockAddr, _, err := client.ProjectIPs.Request(projectID, &req)
+	req.VRFID = d.Get("vrf_id").(string)
+	req.Network = d.Get("network").(string)
+	req.CIDR = d.Get("cidr").(int)
+
+	blockAddr, _, err := client.ProjectIPs.Create(projectID, &req)
 	if err != nil {
 		return fmt.Errorf("Error reserving IP address block: %s", err)
 	}
@@ -320,30 +356,12 @@ func reservedIPStateRefreshFunc(client *packngo.Client, reservedIPId string) res
 	}
 }
 
-func getType(r *packngo.IPAddressReservation) (string, error) {
-	switch {
-	case !r.Public:
-		return fmt.Sprintf("private_ipv%d", r.AddressFamily), nil
-	case r.Public && !r.Global:
-		return fmt.Sprintf("public_ipv%d", r.AddressFamily), nil
-	case r.Public && r.Global:
-		return fmt.Sprintf("global_ipv%d", r.AddressFamily), nil
-	}
-	return "", fmt.Errorf("Unknown reservation type %+v", r)
-}
-
 func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservation) error {
-	ipv4CIDRToQuantity := map[int]int{32: 1, 31: 2, 30: 4, 29: 8, 28: 16, 27: 32, 26: 64, 25: 128, 24: 256}
-
 	d.SetId(reservedBlock.ID)
 
-	typ, err := getType(reservedBlock)
-	if err != nil {
-		return err
-	}
 	quantity := 0
 	if reservedBlock.AddressFamily == 4 {
-		quantity = ipv4CIDRToQuantity[reservedBlock.CIDR]
+		quantity = 1 << (32 - reservedBlock.CIDR)
 	} else {
 		// In Equinix Metal, a reserved IPv6 block is allocated when a device is
 		// run in a project. It's always /56, and it can't be created with
@@ -376,7 +394,7 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 		"netmask":        reservedBlock.Netmask,
 		"address_family": reservedBlock.AddressFamily,
 		"cidr":           reservedBlock.CIDR,
-		"type":           typ,
+		"type":           reservedBlock.Type,
 		"tags":           reservedBlock.Tags,
 		"public":         reservedBlock.Public,
 		"management":     reservedBlock.Management,
@@ -384,6 +402,12 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 		"quantity":       quantity,
 		"project_id":     path.Base(reservedBlock.Project.Href),
 		"cidr_notation":  fmt.Sprintf("%s/%d", reservedBlock.Network, reservedBlock.CIDR),
+		"vrf_id": func(d *schema.ResourceData, k string) error {
+			if reservedBlock.VRF == nil {
+				return nil
+			}
+			return d.Set(k, reservedBlock.VRF.ID)
+		},
 		"custom_data": func(d *schema.ResourceData, k string) error {
 			if reservedBlock.CustomData == nil {
 				return nil
@@ -417,7 +441,10 @@ func resourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*packngo.Client)
 	id := d.Id()
 
-	reservedBlock, _, err := client.ProjectIPs.Get(id, nil)
+	getOpts := &packngo.GetOptions{Includes: []string{"facility", "metro", "project", "vrf"}}
+	getOpts.Filter("types", "public_ipv4,global_ipv4,private_ipv4,public_ipv6,vrf")
+
+	reservedBlock, _, err := client.ProjectIPs.Get(id, getOpts)
 	if err != nil {
 		err = friendlyError(err)
 		if isNotFound(err) {

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -251,7 +251,7 @@ func resourceMetalReservedIPBlockCreate(d *schema.ResourceData, meta interface{}
 		}
 	case "public_ipv4":
 		if !(facOk || metOk) {
-			return fmt.Errorf("You should set either metro or facility for non-global IP block reservation")
+			return fmt.Errorf("you should set either metro or facility for non-global IP block reservation")
 		}
 	}
 
@@ -286,7 +286,7 @@ func resourceMetalReservedIPBlockCreate(d *schema.ResourceData, meta interface{}
 
 	blockAddr, _, err := client.ProjectIPs.Create(projectID, &req)
 	if err != nil {
-		return fmt.Errorf("Error reserving IP address block: %s", err)
+		return fmt.Errorf("error reserving IP address block: %s", err)
 	}
 	d.Set("project_id", projectID)
 	d.SetId(blockAddr.ID)
@@ -305,7 +305,7 @@ func resourceMetalReservedIPBlockCreate(d *schema.ResourceData, meta interface{}
 		MinTimeout: 15 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for IP Reservation (%s) to become %s: %s", d.Id(), wfs, err)
+		return fmt.Errorf("error waiting for IP Reservation (%s) to become %s: %s", d.Id(), wfs, err)
 	}
 
 	return resourceMetalReservedIPBlockRead(d, meta)
@@ -333,13 +333,13 @@ func resourceMetalReservedIPBlockUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("custom_data") {
 		var v interface{}
 		if err := json.Unmarshal([]byte(d.Get("custom_data").(string)), v); err != nil {
-			return fmt.Errorf("Error unmarshalling custom_data: %w", err)
+			return fmt.Errorf("error unmarshalling custom_data: %w", err)
 		}
 		req.CustomData = v
 	}
 
 	if _, _, err := client.ProjectIPs.Update(id, req, nil); err != nil {
-		return fmt.Errorf("Error updating IP reservation: %w", err)
+		return fmt.Errorf("error updating IP reservation: %w", err)
 	}
 
 	return resourceMetalReservedIPBlockRead(d, meta)
@@ -349,7 +349,7 @@ func reservedIPStateRefreshFunc(client *packngo.Client, reservedIPId string) res
 	return func() (interface{}, string, error) {
 		reservedIP, _, err := client.ProjectIPs.Get(reservedIPId, nil)
 		if err != nil {
-			return nil, "", fmt.Errorf("Error retrieving reserved IP block %s: %s", reservedIPId, err)
+			return nil, "", fmt.Errorf("error retrieving reserved IP block %s: %s", reservedIPId, err)
 		}
 
 		return reservedIP, string(reservedIP.State), nil
@@ -370,7 +370,7 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 		// long as /64 is the smallest assignable subnet size.
 		bits := 64 - reservedBlock.CIDR
 		if bits > 30 {
-			return fmt.Errorf("Strange (too small) CIDR prefix: %d", reservedBlock.CIDR)
+			return fmt.Errorf("strange (too small) CIDR prefix: %d", reservedBlock.CIDR)
 		}
 		quantity = 1 << uint(bits)
 	}
@@ -419,7 +419,7 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 			return d.Set(k, string(b))
 		},
 		"description": func(d *schema.ResourceData, k string) error {
-			if (reservedBlock.Description == nil) || (*(reservedBlock.Description) != "") {
+			if (reservedBlock.Description == nil) || (*(reservedBlock.Description) == "") {
 				return nil
 			}
 			return d.Set(k, *(reservedBlock.Description))
@@ -452,7 +452,7 @@ func resourceMetalReservedIPBlockRead(d *schema.ResourceData, meta interface{}) 
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
+		return fmt.Errorf("error reading IP address block with ID %s: %s", id, err)
 	}
 	return loadBlock(d, reservedBlock)
 }
@@ -465,7 +465,7 @@ func resourceMetalReservedIPBlockDelete(d *schema.ResourceData, meta interface{}
 	resp, err := client.ProjectIPs.Remove(id)
 
 	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
-		return fmt.Errorf("Error deleting IP reservation block %s: %s", id, err)
+		return fmt.Errorf("error deleting IP reservation block %s: %s", id, err)
 	}
 
 	d.SetId("")

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -35,7 +35,7 @@ resource "metal_project" "foobar" {
 
 resource "metal_reserved_ip_block" "test" {
 	project_id  = metal_project.foobar.id
-	facility    = "ny5"
+	facility    = "sv"
 	type        = "public_ipv4"
 	quantity    = 2
 	tags        = ["Tag1", "Tag2"]
@@ -101,7 +101,7 @@ func TestAccMetalReservedIPBlock_Public(t *testing.T) {
 				Config: testAccCheckMetalReservedIPBlockConfig_Public(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"metal_reserved_ip_block.test", "facility", "ewr1"),
+						"metal_reserved_ip_block.test", "facility", "sv"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "type", "public_ipv4"),
 					resource.TestCheckResourceAttr(
@@ -230,15 +230,15 @@ resource "metal_project" "foobar" {
 
 resource "metal_reserved_ip_block" "test" {
 	project_id  = metal_project.foobar.id
-	facility    = "ny5"
+	facility    = "ewr1"
 	type        = "public_ipv4"
 	quantity    = 2
 }
 
 resource "metal_device" "test" {
   project_id       = metal_project.foobar.id
-  facilities       = ["ny5"]
-  plan             = "c1.small.x86"
+  facilities       = ["ewr1"]
+  plan             = "c2.medium.x86"
   operating_system = "ubuntu_16_04"
   hostname         = "tfacc-reserved-ip-device"
   billing_cycle    = "hourly"

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -114,6 +114,8 @@ func TestAccMetalReservedIPBlock_Public(t *testing.T) {
 						"metal_reserved_ip_block.test", "management", "false"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "tags.#", "2"),
+					resource.TestCheckResourceAttrSet("metal_reserved_ip_block.test", "network"),
+					resource.TestCheckResourceAttrSet("metal_reserved_ip_block.test", "cidr"),
 				),
 			},
 		},

--- a/metal/resource_metal_reserved_ip_block_test.go
+++ b/metal/resource_metal_reserved_ip_block_test.go
@@ -35,7 +35,7 @@ resource "metal_project" "foobar" {
 
 resource "metal_reserved_ip_block" "test" {
 	project_id  = metal_project.foobar.id
-	facility    = "sv"
+	metro       = "sv"
 	type        = "public_ipv4"
 	quantity    = 2
 	tags        = ["Tag1", "Tag2"]
@@ -101,7 +101,7 @@ func TestAccMetalReservedIPBlock_Public(t *testing.T) {
 				Config: testAccCheckMetalReservedIPBlockConfig_Public(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"metal_reserved_ip_block.test", "facility", "sv"),
+						"metal_reserved_ip_block.test", "metro", "sv"),
 					resource.TestCheckResourceAttr(
 						"metal_reserved_ip_block.test", "type", "public_ipv4"),
 					resource.TestCheckResourceAttr(
@@ -230,15 +230,15 @@ resource "metal_project" "foobar" {
 
 resource "metal_reserved_ip_block" "test" {
 	project_id  = metal_project.foobar.id
-	facility    = "ewr1"
+	facility    = "da11"
 	type        = "public_ipv4"
 	quantity    = 2
 }
 
 resource "metal_device" "test" {
   project_id       = metal_project.foobar.id
-  facilities       = ["ewr1"]
-  plan             = "c2.medium.x86"
+  facilities       = ["da11"]
+  plan             = "c3.medium.x86"
   operating_system = "ubuntu_16_04"
   hostname         = "tfacc-reserved-ip-device"
   billing_cycle    = "hourly"

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -17,8 +17,8 @@ resource "metal_project" "test" {
 }
 
 data "metal_spot_market_price" "test" {
-  facility = "sv15"
-  plan     = "c3.small.x86"
+  facility = "ewr1"
+  plan     = "c2.medium.x86"
 }
 
 data "metal_spot_market_request" "dreq" {
@@ -28,7 +28,7 @@ data "metal_spot_market_request" "dreq" {
 resource "metal_spot_market_request" "request" {
   project_id       = metal_project.test.id
   max_bid_price    = data.metal_spot_market_price.test.price * 1.2
-  facilities       = ["sv15"]
+  facilities       = ["ewr1"]
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
@@ -37,7 +37,7 @@ resource "metal_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_18_04"
-    plan             = "c3.small.x86"
+    plan             = "c2.medium.x86"
   }
 }`, name)
 }
@@ -113,14 +113,14 @@ resource "metal_project" "test" {
 }
 
 data "metal_spot_market_price" "test" {
-  facility = "sv15"
-  plan     = "c3.medium.x86"
+  facility = "ewr1"
+  plan     = "c2.medium.x86"
 }
 
 resource "metal_spot_market_request" "request" {
   project_id       = metal_project.test.id
   max_bid_price    = data.metal_spot_market_price.test.price * 1.2
-  facilities       = ["sv15"]
+  facilities       = ["ewr1"]
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
@@ -129,7 +129,7 @@ resource "metal_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c3.small.x86"
+    plan             = "c2.medium.x86"
   }
 }`, name)
 }

--- a/metal/resource_metal_spot_market_request_test.go
+++ b/metal/resource_metal_spot_market_request_test.go
@@ -17,8 +17,8 @@ resource "metal_project" "test" {
 }
 
 data "metal_spot_market_price" "test" {
-  facility = "ewr1"
-  plan     = "c2.medium.x86"
+  facility = "da11"
+  plan     = "c3.medium.x86"
 }
 
 data "metal_spot_market_request" "dreq" {
@@ -28,7 +28,7 @@ data "metal_spot_market_request" "dreq" {
 resource "metal_spot_market_request" "request" {
   project_id       = metal_project.test.id
   max_bid_price    = data.metal_spot_market_price.test.price * 1.2
-  facilities       = ["ewr1"]
+  facilities       = ["da11"]
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
@@ -37,7 +37,7 @@ resource "metal_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_18_04"
-    plan             = "c2.medium.x86"
+    plan             = "c3.medium.x86"
   }
 }`, name)
 }
@@ -113,14 +113,14 @@ resource "metal_project" "test" {
 }
 
 data "metal_spot_market_price" "test" {
-  facility = "ewr1"
-  plan     = "c2.medium.x86"
+  facility = "da11"
+  plan     = "c3.medium.x86"
 }
 
 resource "metal_spot_market_request" "request" {
   project_id       = metal_project.test.id
   max_bid_price    = data.metal_spot_market_price.test.price * 1.2
-  facilities       = ["ewr1"]
+  facilities       = ["da11"]
   devices_min      = 1
   devices_max      = 1
   wait_for_devices = true
@@ -129,7 +129,7 @@ resource "metal_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_20_04"
-    plan             = "c2.medium.x86"
+    plan             = "c3.medium.x86"
   }
 }`, name)
 }

--- a/metal/resource_metal_virtual_circuit.go
+++ b/metal/resource_metal_virtual_circuit.go
@@ -2,7 +2,10 @@ package metal
 
 import (
 	"fmt"
+	"log"
 	"reflect"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -54,6 +57,7 @@ func resourceMetalVirtualCircuit() *schema.Resource {
 				Description: "Description of the Virtual Circuit speed. This is for information purposes and is computed when the connection type is shared.",
 				Optional:    true,
 				Computed:    true,
+				// TODO: implement SuppressDiffFunc for input with units to bps without units
 			},
 			"tags": {
 				Type:        schema.TypeList,
@@ -68,11 +72,52 @@ func resourceMetalVirtualCircuit() *schema.Resource {
 				ForceNew:    true,
 			},
 			"vlan_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "UUID of the VLAN to associate",
-				ForceNew:    true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "UUID of the VLAN to associate",
+				ExactlyOneOf: []string{"vlan_id", "vrf_id"},
+				ForceNew:     true,
 			},
+			"vrf_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "UUID of the VLAN to associate",
+				ExactlyOneOf: []string{"vlan_id", "vrf_id"},
+				ForceNew:     true,
+			},
+			"peer_asn": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"vrf_id"},
+				Description:  "The BGP ASN of the peer. The same ASN may be the used across several VCs, but it cannot be the same as the local_asn of the VRF.",
+				ForceNew:     true,
+			},
+			"subnet": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vrf_id"},
+				Description: `A subnet from one of the IP blocks associated with the VRF that we will help create an IP reservation for. Can only be either a /30 or /31.
+				 * For a /31 block, it will only have two IP addresses, which will be used for the metal_ip and customer_ip.
+				 * For a /30 block, it will have four IP addresses, but the first and last IP addresses are not usable. We will default to the first usable IP address for the metal_ip.`,
+			},
+			"metal_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vrf_id"},
+				Description:  "The IP address that’s set as “our” IP that is configured on the rack_local_vlan SVI. Will default to the first usable IP in the subnet.",
+			},
+			"customer_ip": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"vrf_id"},
+				Description:  "The IP address set as the customer IP which the CSR switch will peer with. Will default to the other usable IP in the subnet.",
+			},
+			"md5": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The password that can be set for the VRF BGP peer",
+			},
+
 			"vnid": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -99,6 +144,12 @@ func resourceMetalVirtualCircuitCreate(d *schema.ResourceData, meta interface{})
 		Name:             d.Get("name").(string),
 		Description:      d.Get("description").(string),
 		Speed:            d.Get("speed").(string),
+		VRFID:            d.Get("vrf_id").(string),
+		PeerASN:          d.Get("peer_asn").(int),
+		Subnet:           d.Get("subnet").(string),
+		MetalIP:          d.Get("metal_ip").(string),
+		CustomerIP:       d.Get("customer_ip").(string),
+		MD5:              d.Get("md5").(string),
 	}
 
 	connId := d.Get("connection_id").(string)
@@ -113,25 +164,26 @@ func resourceMetalVirtualCircuitCreate(d *schema.ResourceData, meta interface{})
 	if nniVlan, ok := d.GetOk("nni_vlan"); ok {
 		vncr.NniVLAN = nniVlan.(int)
 	}
-
 	conn, _, err := client.Connections.Get(connId, nil)
 	if err != nil {
 		return err
 	}
-	if conn.Status == packngo.VCStatusPending {
+	if conn.Status == string(packngo.VCStatusPending) {
 		return fmt.Errorf("Connection request with name %s and ID %s wasn't approved yet", conn.Name, conn.ID)
 	}
 
 	vc, _, err := client.VirtualCircuits.Create(projectId, connId, portId, &vncr, nil)
 	if err != nil {
+		log.Printf("[DEBUG] Error creating virtual circuit: %s", err)
 		return err
 	}
+	// TODO: offer to wait while VCStatusPending
 	createWaiter := getVCStateWaiter(
 		client,
 		vc.ID,
 		d.Timeout(schema.TimeoutCreate),
-		[]string{packngo.VCStatusActivating},
-		[]string{packngo.VCStatusActive},
+		[]string{string(packngo.VCStatusActivating)},
+		[]string{string(packngo.VCStatusActive)},
 	)
 
 	_, err = createWaiter.WaitForState()
@@ -150,19 +202,38 @@ func resourceMetalVirtualCircuitRead(d *schema.ResourceData, meta interface{}) e
 
 	vc, _, err := client.VirtualCircuits.Get(
 		vcId,
-		&packngo.GetOptions{Includes: []string{"project", "port", "virtual_network"}},
+		&packngo.GetOptions{Includes: []string{"project", "virtual_network", "vrf"}},
 	)
 	if err != nil {
 		return err
 	}
 
+	// TODO: use API field from VC responses when available The regexp is
+	// optimistic, not guaranteed. This affects resource imports. "port" is not
+	// in the Includes above to assure the Href needed below.
+	connectionID := "" // vc.Connection.ID is not available yet
+	portID := ""       // vc.Port.ID would be available with ?include=port
+	connectionRe := regexp.MustCompile("/connections/([0-9a-z-]+)/ports/([0-9a-z-]+)")
+	matches := connectionRe.FindStringSubmatch(vc.Port.Href.Href)
+	if len(matches) == 3 {
+		connectionID = matches[1]
+		portID = matches[2]
+	} else {
+		log.Printf("[DEBUG] Could not parse connection and port ID from port href %s", vc.Port.Href.Href)
+	}
+
 	return setMap(d, map[string]interface{}{
-		"connection_id": d.Get("connection_id").(string),
 		"project_id": vc.Project.ID,
-		"port_id":    vc.Port.ID,
+		"port_id":    portID,
 		"vlan_id": func(d *schema.ResourceData, k string) error {
 			if vc.VirtualNetwork != nil {
 				return d.Set(k, vc.VirtualNetwork.ID)
+			}
+			return nil
+		},
+		"vrf_id": func(d *schema.ResourceData, k string) error {
+			if vc.VRF != nil {
+				return d.Set(k, vc.VRF.ID)
 			}
 			return nil
 		},
@@ -171,9 +242,20 @@ func resourceMetalVirtualCircuitRead(d *schema.ResourceData, meta interface{}) e
 		"vnid":        vc.VNID,
 		"nni_vnid":    vc.NniVNID,
 		"name":        vc.Name,
-		"speed":       vc.Speed,
+		"speed":       strconv.Itoa(vc.Speed),
 		"description": vc.Description,
 		"tags":        vc.Tags,
+		"peer_asn":    vc.PeerASN,
+		"subnet":      vc.Subnet,
+		"metal_ip":    vc.MetalIP,
+		"customer_ip": vc.CustomerIP,
+		"md5":         vc.MD5,
+		"connection_id": func(d *schema.ResourceData, k string) error {
+			if connectionID != "" {
+				return d.Set(k, connectionID)
+			}
+			return nil
+		},
 	})
 }
 
@@ -184,18 +266,20 @@ func getVCStateWaiter(client *packngo.Client, id string, timeout time.Duration, 
 		Refresh: func() (interface{}, string, error) {
 			vc, _, err := client.VirtualCircuits.Get(
 				id,
-				&packngo.GetOptions{Includes: []string{"project", "port", "virtual_network"}},
+				&packngo.GetOptions{Includes: []string{
+					"project", "port", "virtual_network",
+					"vrf",
+				}}, // TODO: we are not using the returned VC. Remove the includes?
 			)
 			if err != nil {
 				return 0, "", err
 			}
-			return vc, vc.Status, nil
+			return vc, string(vc.Status), nil
 		},
 		Timeout:    timeout,
 		Delay:      10 * time.Second,
 		MinTimeout: 5 * time.Second,
 	}
-
 }
 
 func resourceMetalVirtualCircuitUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -241,14 +325,13 @@ func resourceMetalVirtualCircuitUpdate(d *schema.ResourceData, meta interface{})
 		if _, _, err := client.VirtualCircuits.Update(d.Id(), &ur, nil); err != nil {
 			return friendlyError(err)
 		}
-
 	}
 	return resourceMetalVirtualCircuitRead(d, meta)
 }
 
 func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
-	// we first need to disconnect VLAN from the VC
+	// we first disconnect VLAN from the VC
 	empty := ""
 	_, _, err := client.VirtualCircuits.Update(
 		d.Id(),
@@ -259,12 +342,13 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// then we delete the VC. VRF VCs will be in the "active" state.
 	detachWaiter := getVCStateWaiter(
 		client,
 		d.Id(),
 		d.Timeout(schema.TimeoutDelete),
-		[]string{packngo.VCStatusDeactivating},
-		[]string{packngo.VCStatusWaiting},
+		[]string{string(packngo.VCStatusDeactivating)},
+		[]string{string(packngo.VCStatusWaiting), string(packngo.VCStatusActive)},
 	)
 
 	_, err = detachWaiter.WaitForState()
@@ -276,5 +360,19 @@ func resourceMetalVirtualCircuitDelete(d *schema.ResourceData, meta interface{})
 	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
 		return friendlyError(err)
 	}
-	return nil
+
+	deleteWaiter := getVCStateWaiter(
+		client,
+		d.Id(),
+		d.Timeout(schema.TimeoutDelete),
+		[]string{string(packngo.VCStatusDeleting)},
+		[]string{},
+	)
+
+	_, err = deleteWaiter.WaitForState()
+	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) != nil {
+		return nil
+	}
+
+	return fmt.Errorf("Error deleting virtual circuit %s: %s", d.Id(), err)
 }

--- a/metal/resource_metal_virtual_circuit_test.go
+++ b/metal/resource_metal_virtual_circuit_test.go
@@ -2,7 +2,9 @@ package metal
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -10,6 +12,52 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/packethost/packngo"
 )
+
+func init() {
+	resource.AddTestSweepers("metal_virtual_circuit", &resource.Sweeper{
+		Name:         "metal_virtual_circuit",
+		Dependencies: []string{},
+		F:            testSweepVirtualCircuits,
+	})
+}
+
+func testSweepVirtualCircuits(region string) error {
+	log.Printf("[DEBUG] Sweeping VirtualCircuits")
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping VirtualCircuits: %s", err)
+	}
+	metal := config.(*packngo.Client)
+	orgList, _, err := metal.Organizations.List(nil)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting organization list for sweeping VirtualCircuits: %s", err)
+	}
+	vcs := map[string]*packngo.VirtualCircuit{}
+	for _, org := range orgList {
+		conns, _, err := metal.Connections.OrganizationList(org.ID, &packngo.GetOptions{Includes: []string{"ports"}})
+		if err != nil {
+			return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting connections list for sweeping VirtualCircuits: %s", err)
+		}
+		for _, conn := range conns {
+			for _, port := range conn.Ports {
+				for _, vc := range port.VirtualCircuits {
+					if strings.HasPrefix(vc.Name, "tfacc-") {
+						vcs[vc.ID] = &vc
+					}
+				}
+			}
+		}
+	}
+	for _, vc := range vcs {
+		log.Printf("[INFO][SWEEPER_LOG] Deleting VirtualCircuit: %s", vc.Name)
+		_, err := metal.VirtualCircuits.Delete(vc.ID)
+		if err != nil {
+			return fmt.Errorf("[INFO][SWEEPER_LOG] Error deleting VirtualCircuit: %s", err)
+		}
+	}
+
+	return nil
+}
 
 func testAccCheckMetalVirtualCircuitDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*packngo.Client)
@@ -54,7 +102,6 @@ func testAccMetalVirtualCircuitConfig_Dedicated(randstr string, randint int) str
 }
 
 func TestAccMetalVirtualCircuit_Dedicated(t *testing.T) {
-
 	rs := acctest.RandString(10)
 	ri := acctest.RandIntRange(1024, 1093)
 

--- a/metal/resource_metal_vlan_test.go
+++ b/metal/resource_metal_vlan_test.go
@@ -2,6 +2,7 @@ package metal
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -9,6 +10,55 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/packethost/packngo"
 )
+
+func init() {
+	resource.AddTestSweepers("metal_vlan", &resource.Sweeper{
+		Name:         "metal_vlan",
+		Dependencies: []string{"metal_virtual_circuit", "metal_vrf", "metal_device"},
+		F:            testSweepVlans,
+	})
+}
+
+func testSweepVlans(region string) error {
+	log.Printf("[DEBUG] Sweeping vlans")
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping vlans: %s", err)
+	}
+	metal := config.(*packngo.Client)
+	ps, _, err := metal.Projects.List(nil)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting project list for sweeping vlans: %s", err)
+	}
+	pids := []string{}
+	for _, p := range ps {
+		if isSweepableTestResource(p.Name) {
+			pids = append(pids, p.ID)
+		}
+	}
+	dids := []string{}
+	for _, pid := range pids {
+		ds, _, err := metal.ProjectVirtualNetworks.List(pid, nil)
+		if err != nil {
+			log.Printf("Error listing vlans to sweep: %s", err)
+			continue
+		}
+		for _, d := range ds.VirtualNetworks {
+			if isSweepableTestResource(d.Description) {
+				dids = append(dids, d.ID)
+			}
+		}
+	}
+
+	for _, did := range dids {
+		log.Printf("Removing vlan %s", did)
+		_, err := metal.ProjectVirtualNetworks.Delete(did)
+		if err != nil {
+			return fmt.Errorf("Error deleting vlan %s", err)
+		}
+	}
+	return nil
+}
 
 func testAccCheckMetalVlanConfig_metro(projSuffix, metro, desc string) string {
 	return fmt.Sprintf(`
@@ -35,7 +85,7 @@ func TestAccMetalVlan_Metro(t *testing.T) {
 		CheckDestroy: testAccCheckMetalVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, metro, "testvlan"),
+				Config: testAccCheckMetalVlanConfig_metro(rs, metro, "tfacc-vlan"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"metal_vlan.foovlan", "metro", metro),

--- a/metal/resource_metal_vrf.go
+++ b/metal/resource_metal_vrf.go
@@ -1,0 +1,151 @@
+package metal
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func resourceMetalVRF() *schema.Resource {
+	return &schema.Resource{
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+		Read:   resourceMetalVRFRead,
+		Create: resourceMetalVRFCreate,
+		Update: resourceMetalVRFUpdate,
+		Delete: resourceMetalVRFDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "User-supplied name of the VRF, unique to the project",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of the VRF",
+			},
+			"metro": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Metro Code",
+			},
+			"local_asn": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The 4-byte ASN set on the VRF.",
+			},
+			"ip_ranges": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "All IPv4 and IPv6 Ranges that will be available to BGP Peers. IPv4 addresses must be /8 or smaller with a minimum size of /29. IPv6 must be /56 or smaller with a minimum size of /64. Ranges must not overlap other ranges within the VRF.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Project ID",
+			},
+			// TODO: created_by, created_at, updated_at, href
+		},
+	}
+}
+
+func resourceMetalVRFCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	createRequest := &packngo.VRFCreateRequest{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Metro:       d.Get("metro").(string),
+		LocalASN:    d.Get("local_asn").(int),
+		IPRanges:    expandSetToStringList(d.Get("ip_ranges").(*schema.Set)),
+	}
+
+	projectId := d.Get("project_id").(string)
+	vrf, _, err := client.VRFs.Create(projectId, createRequest)
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	d.SetId(vrf.ID)
+
+	return resourceMetalVRFRead(d, meta)
+}
+
+func resourceMetalVRFUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	sPtr := func(s string) *string { return &s }
+	iPtr := func(i int) *int { return &i }
+
+	updateRequest := &packngo.VRFUpdateRequest{}
+	if d.HasChange("name") {
+		updateRequest.Name = sPtr(d.Get("name").(string))
+	}
+	if d.HasChange("description") {
+		updateRequest.Description = sPtr(d.Get("description").(string))
+	}
+	if d.HasChange("local_asn") {
+		updateRequest.LocalASN = iPtr(d.Get("local_asn").(int))
+	}
+	if d.HasChange("ip_ranges") {
+		ipRanges := expandSetToStringList(d.Get("ip_ranges").(*schema.Set))
+		updateRequest.IPRanges = &ipRanges
+	}
+
+	_, _, err := client.VRFs.Update(d.Id(), updateRequest)
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	return resourceMetalVRFRead(d, meta)
+}
+
+func resourceMetalVRFRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	getOpts := &packngo.GetOptions{Includes: []string{"project", "metro"}}
+
+	vrf, _, err := client.VRFs.Get(d.Id(), getOpts)
+	if err != nil {
+		if isNotFound(err) || isForbidden(err) {
+			log.Printf("[WARN] VRF (%s) not accessible, removing from state", d.Id())
+			d.SetId("")
+
+			return nil
+		}
+		return err
+	}
+	m := map[string]interface{}{
+		"name":        vrf.Name,
+		"description": vrf.Description,
+		"metro":       vrf.Metro.Code,
+		"local_asn":   vrf.LocalASN,
+		"ip_ranges":   vrf.IPRanges,
+		"project_id":  vrf.Project.ID,
+	}
+
+	return setMap(d, m)
+}
+
+func resourceMetalVRFDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	resp, err := client.VRFs.Delete(d.Id())
+	if ignoreResponseErrors(httpForbidden, httpNotFound)(resp, err) == nil {
+		d.SetId("")
+	}
+
+	return friendlyError(err)
+}

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -172,6 +172,7 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 				ResourceName:      "metal_reserved_ip_block.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},
 	})
@@ -220,7 +221,7 @@ func TestAccMetalVRF_withGateway(t *testing.T) {
 func TestAccMetalVRFConfig_withConnection(t *testing.T) {
 	var vrf packngo.VRF
 	rInt := acctest.RandInt()
-	nniVlan := acctest.RandIntRange(1024, 1093)
+	nniVlan := acctest.RandIntRange(2024, 2093)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -1,0 +1,461 @@
+package metal
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/packethost/packngo"
+)
+
+func init() {
+	resource.AddTestSweepers("metal_vrf", &resource.Sweeper{
+		Name: "metal_vrf",
+		Dependencies: []string{
+			"metal_device",
+			"metal_virtual_circuit",
+			// TODO: add sweeper when offered
+			// "metal_reserved_ip_block",
+		},
+		F: testSweepVRFs,
+	})
+}
+
+func testSweepVRFs(region string) error {
+	log.Printf("[DEBUG] Sweeping VRFs")
+	config, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting configuration for sweeping VRFs: %s", err)
+	}
+	metal := config.(*packngo.Client)
+	ps, _, err := metal.Projects.List(nil)
+	if err != nil {
+		return fmt.Errorf("[INFO][SWEEPER_LOG] Error getting project list for sweeping VRFs: %s", err)
+	}
+	pids := []string{}
+	for _, p := range ps {
+		if isSweepableTestResource(p.Name) {
+			pids = append(pids, p.ID)
+		}
+	}
+	dids := []string{}
+	for _, pid := range pids {
+		ds, _, err := metal.VRFs.List(pid, nil)
+		if err != nil {
+			log.Printf("Error listing VRFs to sweep: %s", err)
+			continue
+		}
+		for _, d := range ds {
+			if isSweepableTestResource(d.Name) {
+				dids = append(dids, d.ID)
+			}
+		}
+	}
+
+	for _, did := range dids {
+		log.Printf("Removing VRFs %s", did)
+		_, err := metal.VRFs.Delete(did)
+		if err != nil {
+			return fmt.Errorf("Error deleting VRFs %s", err)
+		}
+	}
+	return nil
+}
+
+func TestAccMetalVRF_basic(t *testing.T) {
+	var vrf packngo.VRF
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+					resource.TestCheckResourceAttrSet(
+						"metal_vrf.test", "local_asn"),
+				),
+			},
+			{
+				ResourceName:      "metal_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMetalVRF_withIPRanges(t *testing.T) {
+	var vrf packngo.VRF
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+				),
+			},
+			{
+				Config: testAccMetalVRFConfig_withIPRanges(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+				),
+			},
+			{
+				ResourceName:      "metal_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMetalVRFConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMetalVRF_withIPReservations(t *testing.T) {
+	var vrf packngo.VRF
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_withIPRanges(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+				),
+			},
+			{
+				Config: testAccMetalVRFConfig_withIPReservations(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+					resource.TestCheckResourceAttrPair("metal_vrf.test", "id", "metal_reserved_ip_block.test", "vrf_id"),
+				),
+			},
+			{
+				ResourceName:      "metal_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "metal_reserved_ip_block.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMetalVRF_withGateway(t *testing.T) {
+	var vrf packngo.VRF
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_withIPReservations(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+				),
+			},
+			{
+				Config: testAccMetalVRFConfig_withGateway(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_vrf.test", "name", fmt.Sprintf("tfacc-vrf-%d", rInt)),
+					resource.TestCheckResourceAttrPair("metal_vrf.test", "id", "metal_gateway.test", "vrf_id"),
+				),
+			},
+			{
+				ResourceName:      "metal_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "metal_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMetalVRFConfig_withConnection(t *testing.T) {
+	var vrf packngo.VRF
+	rInt := acctest.RandInt()
+	nniVlan := acctest.RandIntRange(1024, 1093)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccMetalVRFCheckDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetalVRFConfig_withVC(rInt, nniVlan),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMetalVRFExists("metal_vrf.test", &vrf),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test", "name", fmt.Sprintf("tfacc-vc-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test",
+						"nni_vlan", strconv.Itoa(nniVlan)),
+					resource.TestCheckResourceAttrPair(
+						"metal_virtual_circuit.test",
+						"vrf_id", "metal_vrf.test", "id"),
+					resource.TestCheckNoResourceAttr(
+						"metal_virtual_circuit.test",
+						"vlan_id"),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test",
+						"peer_asn", "65530"),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test",
+						"subnet", "192.168.100.16/31"),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test",
+						"metal_ip", "192.168.100.16"),
+					resource.TestCheckResourceAttr(
+						"metal_virtual_circuit.test",
+						"customer_ip", "192.168.100.17"),
+				),
+			},
+			{
+				ResourceName:      "metal_virtual_circuit.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccMetalVRFConfig_withVCGateway(rInt, nniVlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"metal_virtual_circuit.test",
+						"vlan_id"),
+				),
+			},
+			{
+				ResourceName:      "metal_reserved_ip_block.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "metal_vlan.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "metal_gateway.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccMetalVRFCheckDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "metal_vrf" {
+			continue
+		}
+		if _, _, err := client.VRFs.Get(rs.Primary.ID, nil); err == nil {
+			return fmt.Errorf("Metal VRF still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccMetalVRFExists(n string, vrf *packngo.VRF) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*packngo.Client)
+
+		foundResource, _, err := client.VRFs.Get(rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
+		if foundResource.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found: %v - %v", rs.Primary.ID, foundResource)
+		}
+
+		*vrf = *foundResource
+
+		return nil
+	}
+}
+
+func testAccMetalVRFConfig_basic(r int) string {
+	testMetro := "da"
+
+	return fmt.Sprintf(`
+resource "metal_project" "test" {
+    name = "tfacc-vrfs-%d"
+}
+
+resource "metal_vrf" "test" {
+	name = "tfacc-vrf-%d"
+	metro = "%s"
+	project_id = "${metal_project.test.id}"
+}`, r, r, testMetro)
+}
+
+func testAccMetalVRFConfig_withIPRanges(r int) string {
+	testMetro := "da"
+
+	return fmt.Sprintf(`
+resource "metal_project" "test" {
+    name = "tfacc-vrfs-%d"
+}
+
+resource "metal_vrf" "test" {
+	name = "tfacc-vrf-%d"
+	metro = "%s"
+	description = "tfacc-vrf-%d"
+	local_asn = "65000"
+	ip_ranges = ["192.168.100.0/25"]
+	project_id = metal_project.test.id
+}`, r, r, testMetro, r)
+}
+
+func testAccMetalVRFConfig_withIPReservations(r int) string {
+	testMetro := "da"
+
+	return testAccMetalVRFConfig_withIPRanges(r) + fmt.Sprintf(`
+
+resource "metal_reserved_ip_block" "test" {
+	vrf_id = metal_vrf.test.id
+	cidr = 29
+	description = "tfacc-reserved-ip-block-%d"
+	network = "192.168.100.0"
+	type = "vrf"
+	metro = "%s"
+	project_id = metal_project.test.id
+}
+`, r, testMetro)
+}
+
+func testAccMetalVRFConfig_withGateway(r int) string {
+	testMetro := "da"
+
+	return testAccMetalVRFConfig_withIPReservations(r) + fmt.Sprintf(`
+
+resource "metal_vlan" "test" {
+	description = "tfacc-vlan-vrf"
+	metro       = "%s"
+	project_id  = metal_project.test.id
+}
+
+resource "metal_gateway" "test" {
+    project_id        = metal_project.test.id
+    vlan_id           = metal_vlan.test.id
+    ip_reservation_id = metal_reserved_ip_block.test.id
+}
+`, testMetro)
+}
+
+func testAccMetalVRFConfig_withVC(r, nniVlan int) string {
+	// Dedicated connection in DA metro
+	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
+	return testAccMetalVRFConfig_withIPRanges(r) + fmt.Sprintf(`
+
+	data "metal_connection" "test" {
+		connection_id = "%s"
+	}
+
+	resource "metal_virtual_circuit" "test" {
+		name = "tfacc-vc-%d"
+		description = "tfacc-vc-%d"
+		connection_id = data.metal_connection.test.id
+		project_id = metal_project.test.id
+		port_id = data.metal_connection.test.ports[0].id
+		nni_vlan = %d
+		vrf_id = metal_vrf.test.id
+		peer_asn = 65530
+		subnet = "192.168.100.16/31"
+		metal_ip = "192.168.100.16"
+		customer_ip = "192.168.100.17"
+	}
+	`, testConnection, r, r, nniVlan)
+}
+
+func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
+	// Dedicated connection in DA metro
+	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
+	return testAccMetalVRFConfig_withGateway(r) + fmt.Sprintf(`
+	data "metal_connection" "test" {
+		connection_id = "%s"
+	}
+
+	resource "metal_virtual_circuit" "test" {
+		name = "tfacc-vc-%d"
+		description = "tfacc-vc-%d"
+		connection_id = data.metal_connection.test.id
+		project_id = metal_project.test.id
+		port_id = data.metal_connection.test.ports[0].id
+		nni_vlan = %d
+		vrf_id = metal_vrf.test.id
+		peer_asn = 65530
+		subnet = "192.168.100.16/31"
+		metal_ip = "192.168.100.16"
+		customer_ip = "192.168.100.17"
+	}`, testConnection, r, r, nniVlan)
+}
+
+func testAccMetalVRFConfig_withConnection(r int) string {
+	testMetro := "da"
+	return testAccMetalVRFConfig_basic(r) + fmt.Sprintf(`
+
+	resource "metal_connection" "test" {
+		name            = "tfacc-conn-%d"
+		organization_id = metal_project.foobar.organization_id
+		project_id      = metal_project.foobar.id
+		metro           = "%s"
+		redundancy      = "redundant"
+		type            = "shared"
+	}`, r, testMetro)
+}

--- a/metal/sweeper_test.go
+++ b/metal/sweeper_test.go
@@ -3,10 +3,13 @@ package metal
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
+
+const tstResourcePrefix = "tfacc"
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
@@ -28,4 +31,8 @@ func sharedConfigForRegion(region string) (interface{}, error) {
 	}
 
 	return config.Client(), nil
+}
+
+func isSweepableTestResource(namePrefix string) bool {
+	return strings.HasPrefix(namePrefix, tstResourcePrefix)
 }


### PR DESCRIPTION
This is a backport of equinix/terraform-provider-equinix#129

Mostly derived from
https://patch-diff.githubusercontent.com/raw/equinix/terraform-provider-equinix/pull/129.patch
with some automated changes to the patch and manually cherry-picked changes from the rejects.

```
# vim commands applied against the patch
:%s_equinix/_metal/
:%s/equinix_//
:%s/data_source_metal/datasource_metal
:%s/_acc_test.go/_test.go
:%s/package equinix/package metal
:%s#docs/resources/metal_#docs/resources/
:%s#docs/data-sources/metal_#docs/data-sources/
```

Patch applied with:

```
patch -p1 --input=129.patch --fuzz=16
```

Rejects reviewed with:
```
find . -name \*rej  -exec less {} \;
```

Notably, rejects that dealt with test locations and plans were ignored for this PR.
Some helper tools for set/list conversion and sweeper test detection where copied from equinix/equinix.