### PR TITLE
field address added to rs/ds metal_organization

### DIFF
--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -40,3 +40,9 @@ The following attributes are exported:
 * `website` - Website link
 * `twitter` - Twitter handle
 * `logo` - Logo URL
+* `address` - Address information
+  * `address` - Postal address.
+  * `city` - City name.
+  * `country` - Two letter country code (ISO 3166-1 alpha-2), e.g. US.
+  * `zip_code` - Zip Code.
+  * `state` - State name.

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -24,10 +24,22 @@ resource "metal_organization" "tf_organization_1" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Organization
-* `description` - Description string
-* `website` - Website link
-* `twitter` - Twitter handle
-* `logo` - Logo URL
+* `address` - (Required) An object that has the address information. See [Address](#address)
+below for more details.
+* `description` - (Optional) Description string
+* `website` - (Optional) Website link
+* `twitter` - (Optional) Twitter handle
+* `logo` - (Optional) Logo URL
+
+### Address
+
+The `address` block contains:
+
+* `address` - (Required) Postal address.
+* `city` - (Required) City name.
+* `country` - (Required) Two letter country code (ISO 3166-1 alpha-2), e.g. US.
+* `zip_code` - (Required) Zip Code.
+* `state` - (Optional) State name.
 
 ## Attributes Reference
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.9.0
-	github.com/packethost/packngo v0.23.0
+	github.com/packethost/packngo v0.25.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/packethost/packngo v0.23.0 h1:AnG26Th7v68solhArM/sF/mCB8hV2LI70VYxebF4bgE=
-github.com/packethost/packngo v0.23.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
+github.com/packethost/packngo v0.25.0 h1:ujGXL3lVqTiaQoX2/Go74lQAlYfTeop7jBNy5w99w2A=
+github.com/packethost/packngo v0.25.0/go.mod h1:/UHguFdPs6Lf6FOkkSEPnRY5tgS0fsVM+Zv/bvBrmt0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/metal/datasource_metal_organization.go
+++ b/metal/datasource_metal_organization.go
@@ -143,6 +143,7 @@ func dataSourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) e
 		projectIds = append(projectIds, path.Base(p.URL))
 	}
 
+	d.SetId(org.ID)
 	return setMap(d, map[string]interface{}{
 		"organization_id": org.ID,
 		"name":            org.Name,

--- a/metal/datasource_metal_organization.go
+++ b/metal/datasource_metal_organization.go
@@ -32,13 +32,11 @@ func dataSourceMetalOrganization() *schema.Resource {
 				Description: "Description string",
 				Computed:    true,
 			},
-
 			"website": {
 				Type:        schema.TypeString,
 				Description: "Website link",
 				Computed:    true,
 			},
-
 			"twitter": {
 				Type:        schema.TypeString,
 				Description: "Twitter handle",
@@ -55,6 +53,46 @@ func dataSourceMetalOrganization() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"address": {
+				Type:        schema.TypeList,
+				Description: "Business' address",
+				Computed:    true,
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: createOrganizationAddressDataSourceSchema(),
+				},
+			},
+		},
+	}
+}
+
+func createOrganizationAddressDataSourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"address": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		"city": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		"zip_code": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		"country": {
+			Type:        schema.TypeString,
+			Description: "Two letter country code (ISO 3166-1 alpha-2), e.g. US",
+			Computed:    true,
+			Optional:    true,
+		},
+		"state": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
 		},
 	}
 }
@@ -81,14 +119,14 @@ func dataSourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) e
 	orgIdRaw, orgIdOK := d.GetOk("organization_id")
 
 	if !orgIdOK && !nameOK {
-		return fmt.Errorf("You must supply organization_id or name")
+		return fmt.Errorf("you must supply organization_id or name")
 	}
 	var org *packngo.Organization
 
 	if nameOK {
 		name := nameRaw.(string)
 
-		os, _, err := client.Organizations.List(nil)
+		os, _, err := client.Organizations.List(&packngo.GetOptions{Includes: []string{"address"}})
 		if err != nil {
 			return err
 		}
@@ -100,7 +138,7 @@ func dataSourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) e
 	} else {
 		orgId := orgIdRaw.(string)
 		var err error
-		org, _, err = client.Organizations.Get(orgId, nil)
+		org, _, err = client.Organizations.Get(orgId, &packngo.GetOptions{Includes: []string{"address"}})
 		if err != nil {
 			return err
 		}
@@ -111,14 +149,14 @@ func dataSourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) e
 		projectIds = append(projectIds, path.Base(p.URL))
 	}
 
-	d.Set("organization_id", org.ID)
-	d.Set("name", org.Name)
-	d.Set("description", org.Description)
-	d.Set("website", org.Website)
-	d.Set("twitter", org.Twitter)
-	d.Set("logo", org.Logo)
-	d.Set("project_ids", projectIds)
-	d.SetId(org.ID)
-
-	return nil
+	return setMap(d, map[string]interface{}{
+		"organization_id": org.ID,
+		"name":            org.Name,
+		"description":     org.Description,
+		"website":         org.Website,
+		"twitter":         org.Twitter,
+		"logo":            org.Logo,
+		"project_ids":     projectIds,
+		"address":         flattenMetalOrganizationAddress(org.Address),
+	})
 }

--- a/metal/datasource_metal_organization.go
+++ b/metal/datasource_metal_organization.go
@@ -57,7 +57,6 @@ func dataSourceMetalOrganization() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Business' address",
 				Computed:    true,
-				Optional:    true,
 				Elem: &schema.Resource{
 					Schema: createOrganizationAddressDataSourceSchema(),
 				},
@@ -71,28 +70,23 @@ func createOrganizationAddressDataSourceSchema() map[string]*schema.Schema {
 		"address": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"city": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"zip_code": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 		"country": {
 			Type:        schema.TypeString,
 			Description: "Two letter country code (ISO 3166-1 alpha-2), e.g. US",
 			Computed:    true,
-			Optional:    true,
 		},
 		"state": {
 			Type:     schema.TypeString,
 			Computed: true,
-			Optional: true,
 		},
 	}
 }

--- a/metal/datasource_metal_organization_test.go
+++ b/metal/datasource_metal_organization_test.go
@@ -30,6 +30,22 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.metal_organization.test", "name",
 						fmt.Sprintf("tfacc-datasource-org-%d", rInt)),
+					resource.TestCheckResourceAttrPair(
+						"metal_organization.test", "address.0.address",
+						"data.metal_organization.test", "address.0.address",
+					),
+					resource.TestCheckResourceAttrPair(
+						"metal_organization.test", "address.0.city",
+						"data.metal_organization.test", "address.0.city",
+					),
+					resource.TestCheckResourceAttrPair(
+						"metal_organization.test", "address.0.country",
+						"data.metal_organization.test", "address.0.country",
+					),
+					resource.TestCheckResourceAttrPair(
+						"metal_organization.test", "address.0.zip_code",
+						"data.metal_organization.test", "address.0.zip_code",
+					),
 				),
 			},
 		},
@@ -41,12 +57,17 @@ func testAccCheckMetalOrgDataSourceConfigBasic(r int) string {
 resource "metal_organization" "test" {
   name = "tfacc-datasource-org-%d"
   description = "quux"
+  address {
+	address = "tfacc org street"
+	city = "london"
+	zip_code = "12345"
+	country = "GB"
+  }
 }
 
 data "metal_organization" "test" {
   organization_id = metal_organization.test.id
 }
-
 
 `, r)
 }

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -130,3 +130,13 @@ var resourceDefaultTimeouts = &schema.ResourceTimeout{
 	Delete:  schema.DefaultTimeout(60 * time.Minute),
 	Default: schema.DefaultTimeout(60 * time.Minute),
 }
+
+func getResourceDataChangedKeys(keys []string, d *schema.ResourceData) map[string]interface{} {
+	changed := make(map[string]interface{})
+	for _, key := range keys {
+		if v := d.Get(key); v != nil && d.HasChange(key) {
+			changed[key] = v
+		}
+	}
+	return changed
+}

--- a/metal/resource_metal_organization.go
+++ b/metal/resource_metal_organization.go
@@ -150,7 +150,6 @@ func resourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(key.ID)
-
 	return setMap(d, map[string]interface{}{
 		"name":        key.Name,
 		"description": key.Description,

--- a/metal/resource_metal_organization.go
+++ b/metal/resource_metal_organization.go
@@ -27,25 +27,21 @@ func resourceMetalOrganization() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Description string",
 				Optional:    true,
-				Required:    false,
 			},
 			"website": {
 				Type:        schema.TypeString,
 				Description: "Website link",
 				Optional:    true,
-				Required:    false,
 			},
 			"twitter": {
 				Type:        schema.TypeString,
 				Description: "Twitter handle",
 				Optional:    true,
-				Required:    false,
 			},
 			"logo": {
 				Type:        schema.TypeString,
 				Description: "Logo URL",
 				Optional:    true,
-				Required:    false,
 			},
 			"created": {
 				Type:     schema.TypeString,

--- a/metal/resource_metal_organization.go
+++ b/metal/resource_metal_organization.go
@@ -2,7 +2,9 @@ package metal
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/packethost/packngo"
+	"regexp"
 )
 
 func resourceMetalOrganization() *schema.Resource {
@@ -21,44 +23,81 @@ func resourceMetalOrganization() *schema.Resource {
 				Description: "The name of the Organization",
 				Required:    true,
 			},
-
 			"description": {
 				Type:        schema.TypeString,
 				Description: "Description string",
 				Optional:    true,
 				Required:    false,
 			},
-
 			"website": {
 				Type:        schema.TypeString,
 				Description: "Website link",
 				Optional:    true,
 				Required:    false,
 			},
-
 			"twitter": {
 				Type:        schema.TypeString,
 				Description: "Twitter handle",
 				Optional:    true,
 				Required:    false,
 			},
-
 			"logo": {
 				Type:        schema.TypeString,
 				Description: "Logo URL",
 				Optional:    true,
 				Required:    false,
 			},
-
 			"created": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"updated": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"address": {
+				Type:        schema.TypeList,
+				Description: "Address information block",
+				Required:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: createMetalOrganizationAddressResourceSchema(),
+				},
+			},
+		},
+	}
+}
+
+func createMetalOrganizationAddressResourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"address": {
+			Type:         schema.TypeString,
+			Description:  "Postal address",
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"city": {
+			Type:         schema.TypeString,
+			Description:  "City name",
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"zip_code": {
+			Type:         schema.TypeString,
+			Description:  "Zip Code",
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"country": {
+			Type:         schema.TypeString,
+			Description:  "Two letter country code (ISO 3166-1 alpha-2), e.g. US",
+			Required:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile("(?i)^[a-z]{2}$"), "Address country must be a two letter code (ISO 3166-1 alpha-2)"),
+		},
+		"state": {
+			Type:        schema.TypeString,
+			Description: "State name",
+			Optional:    true,
 		},
 	}
 }
@@ -67,7 +106,8 @@ func resourceMetalOrganizationCreate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*packngo.Client)
 
 	createRequest := &packngo.OrganizationCreateRequest{
-		Name: d.Get("name").(string),
+		Name:    d.Get("name").(string),
+		Address: expandMetalOrganizationAddress(d.Get("address").([]interface{})),
 	}
 
 	if attr, ok := d.GetOk("website"); ok {
@@ -99,7 +139,7 @@ func resourceMetalOrganizationCreate(d *schema.ResourceData, meta interface{}) e
 func resourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 
-	key, _, err := client.Organizations.Get(d.Id(), nil)
+	key, _, err := client.Organizations.Get(d.Id(), &packngo.GetOptions{Includes: []string{"address"}})
 	if err != nil {
 		err = friendlyError(err)
 
@@ -114,46 +154,48 @@ func resourceMetalOrganizationRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(key.ID)
-	d.Set("name", key.Name)
-	d.Set("description", key.Description)
-	d.Set("website", key.Website)
-	d.Set("twitter", key.Twitter)
-	d.Set("logo", key.Logo)
-	d.Set("created", key.Created)
-	d.Set("updated", key.Updated)
 
-	return nil
+	return setMap(d, map[string]interface{}{
+		"name":        key.Name,
+		"description": key.Description,
+		"website":     key.Website,
+		"twitter":     key.Twitter,
+		"logo":        key.Logo,
+		"created":     key.Created,
+		"updated":     key.Updated,
+		"address":     flattenMetalOrganizationAddress(key.Address),
+	})
 }
 
 func resourceMetalOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 
+	changes := getResourceDataChangedKeys([]string{"name", "description", "website", "twitter", "logo", "address"}, d)
 	updateRequest := &packngo.OrganizationUpdateRequest{}
 
-	if d.HasChange("name") {
-		oName := d.Get("name").(string)
-		updateRequest.Name = &oName
+	for change, changeValue := range changes {
+		switch change {
+		case "name":
+			cv := changeValue.(string)
+			updateRequest.Name = &cv
+		case "description":
+			cv := changeValue.(string)
+			updateRequest.Description = &cv
+		case "website":
+			cv := changeValue.(string)
+			updateRequest.Website = &cv
+		case "twitter":
+			cv := changeValue.(string)
+			updateRequest.Twitter = &cv
+		case "logo":
+			cv := changeValue.(string)
+			updateRequest.Logo = &cv
+		case "address":
+			cv := expandMetalOrganizationAddress(changeValue.([]interface{}))
+			updateRequest.Address = &cv
+		}
 	}
 
-	if d.HasChange("description") {
-		oDescription := d.Get("description").(string)
-		updateRequest.Description = &oDescription
-	}
-
-	if d.HasChange("website") {
-		oWebsite := d.Get("website").(string)
-		updateRequest.Website = &oWebsite
-	}
-
-	if d.HasChange("twitter") {
-		oTwitter := d.Get("twitter").(string)
-		updateRequest.Twitter = &oTwitter
-	}
-
-	if d.HasChange("logo") {
-		oLogo := d.Get("logo").(string)
-		updateRequest.Logo = &oLogo
-	}
 	_, _, err := client.Organizations.Update(d.Id(), updateRequest)
 	if err != nil {
 		return friendlyError(err)
@@ -172,4 +214,51 @@ func resourceMetalOrganizationDelete(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId("")
 	return nil
+}
+
+func flattenMetalOrganizationAddress(addr packngo.Address) interface{} {
+	result := make(map[string]interface{})
+	if addr.Address != "" {
+		result["address"] = addr.Address
+	}
+	if addr.City != nil && *addr.City != "" {
+		result["city"] = addr.City
+	}
+	if addr.Country != "" {
+		result["country"] = addr.Country
+	}
+	if addr.State != nil && *addr.State != "" {
+		result["state"] = addr.State
+	}
+	if addr.ZipCode != "" {
+		result["zip_code"] = addr.ZipCode
+	}
+
+	return []interface{}{result}
+}
+
+func expandMetalOrganizationAddress(address []interface{}) packngo.Address {
+
+	transformed := packngo.Address{}
+	addr := address[0].(map[string]interface{})
+
+	if v, ok := addr["address"]; ok {
+		transformed.Address = v.(string)
+	}
+	if v, ok := addr["city"]; ok {
+		city := v.(string)
+		transformed.City = &city
+	}
+	if v, ok := addr["zip_code"]; ok {
+		transformed.ZipCode = v.(string)
+	}
+	if v, ok := addr["country"]; ok {
+		transformed.Country = v.(string)
+	}
+	if v, ok := addr["state"]; ok {
+		state := v.(string)
+		transformed.State = &state
+	}
+
+	return transformed
 }

--- a/metal/resource_metal_project_test.go
+++ b/metal/resource_metal_project_test.go
@@ -404,11 +404,17 @@ func testAccCheckMetalProjectOrgConfig(r string) string {
 	return fmt.Sprintf(`
 resource "metal_organization" "test" {
 	name = "tfacc-project-%s"
+	address {
+		address = "tfacc org street"
+		city = "london"
+		zip_code = "12345"
+		country = "GB"
+	}
 }
 
 resource "metal_project" "foobar" {
-		name = "tfacc-project-%s"
-		organization_id = "${metal_organization.test.id}"
+	name = "tfacc-project-%s"
+	organization_id = "${metal_organization.test.id}"
 }`, r, r)
 }
 

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -169,9 +169,9 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "metal_reserved_ip_block.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "metal_reserved_ip_block.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},


### PR DESCRIPTION
This PR adds field address (mandatory now to create an organization) in both resource and data source metal_organization.

Sync with https://github.com/equinix/terraform-provider-equinix/pull/137
- Allow retrieve previous organization without address.
- Test updated.
- Documentation updated.

fix https://github.com/equinix/terraform-provider-metal/issues/230