### PR TITLE
Fix test sweepers for metal projects

### DIFF
--- a/metal/datasource_metal_device_test.go
+++ b/metal/datasource_metal_device_test.go
@@ -40,7 +40,7 @@ func TestAccDataSourceMetalDevice_Basic(t *testing.T) {
 func testDataSourceMetalDeviceConfig_Basic(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-project-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -90,7 +90,7 @@ func TestAccDataSourceMetalDevice_ByID(t *testing.T) {
 func testDataSourceMetalDeviceConfig_ByID(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-project-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/datasource_metal_gateway_test.go
+++ b/metal/datasource_metal_gateway_test.go
@@ -10,7 +10,7 @@ import (
 func testAccDataSourceMetalGatewayConfig_PrivateIPv4() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "tfacc-gateway-test"
+	name = "tfacc-pro-gateway-test"
 }
 
 resource "metal_vlan" "test" {

--- a/metal/datasource_metal_gateway_test.go
+++ b/metal/datasource_metal_gateway_test.go
@@ -10,25 +10,25 @@ import (
 func testAccDataSourceMetalGatewayConfig_PrivateIPv4() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-gateway-test"
+	name = "tfacc-gateway-test"
 }
 
 resource "metal_vlan" "test" {
-    description = "test VLAN in SV"
-    metro       = "sv"
-    project_id  = metal_project.test.id
+	description = "%s-vlan in SV"
+	metro       = "sv"
+	project_id  = metal_project.test.id
 }
 
 resource "metal_gateway" "test" {
-    project_id               = metal_project.test.id
-    vlan_id                  = metal_vlan.test.id
-    private_ipv4_subnet_size = 8
+	project_id               = metal_project.test.id
+	vlan_id                  = metal_vlan.test.id
+	private_ipv4_subnet_size = 8
 }
 
 data "metal_gateway" "test" {
-    gateway_id = metal_gateway.test.id
+	gateway_id = metal_gateway.test.id
 }
-`)
+`, tstResourcePrefix)
 }
 
 func TestAccDataSourceMetalGateway_PrivateIPv4(t *testing.T) {

--- a/metal/datasource_metal_ip_block_ranges_test.go
+++ b/metal/datasource_metal_ip_block_ranges_test.go
@@ -39,7 +39,7 @@ func testIPBlockRangesConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-    name = "tfacc-precreated_ip_block-%s"
+    name = "tfacc-pro-precreated_ip_block-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/datasource_metal_port_test.go
+++ b/metal/datasource_metal_port_test.go
@@ -31,7 +31,7 @@ func testPortConfig_ByName(name string) string {
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-    name = "tfacc-port-%s"
+    name = "tfacc-pro-port-%s"
 }
 
 resource "metal_device" "test" {
@@ -74,7 +74,7 @@ func testPortConfig_ById(name string) string {
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-    name = "tfacc-port-%s"
+    name = "tfacc-pro-port-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/datasource_metal_precreated_ip_block_test.go
+++ b/metal/datasource_metal_precreated_ip_block_test.go
@@ -39,7 +39,7 @@ func testDatasourcePreCreatedIPBlockConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-    name = "tfacc-precreated_ip_block-%s"
+    name = "tfacc-pro-recreated_ip_block-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/datasource_metal_project_ssh_key_test.go
+++ b/metal/datasource_metal_project_ssh_key_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccMetalProjectSSHKeyDataSource_BySearch(t *testing.T) {
 	datasourceName := "data.metal_project_ssh_key.foobar"
-	keyName := acctest.RandomWithPrefix("tfacc-project-key")
+	keyName := acctest.RandomWithPrefix("tfacc-pro-key")
 
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")
 
@@ -52,7 +52,7 @@ func TestAccMetalProjectSSHKeyDataSource_ByID(t *testing.T) {
 	datasourceName := "data.metal_project_ssh_key.foobar"
 
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")
-	keyName := acctest.RandomWithPrefix("tfacc-project-key")
+	keyName := acctest.RandomWithPrefix("tfacc-pro-key")
 
 	if err != nil {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)

--- a/metal/datasource_metal_project_test.go
+++ b/metal/datasource_metal_project_test.go
@@ -12,7 +12,7 @@ import (
 func testAccCheckMetalDataSourceProject_Basic(r string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-	name = "tfacc-project-%s"
+	name = "tfacc-pro-%s"
 	bgp_config {
 		deployment_type = "local"
 		md5 = "2SFsdfsg43"

--- a/metal/datasource_metal_reserved_ip_block_test.go
+++ b/metal/datasource_metal_reserved_ip_block_test.go
@@ -11,7 +11,7 @@ import (
 func testAccDataSourceMetalReservedIPBlockConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-	name = "tfacc-reserved_ip_block-%s"
+	name = "tfacc-pro-reserved_ip_block-%s"
 }
 
 resource "metal_reserved_ip_block" "test" {

--- a/metal/datasource_metal_spot_market_request_test.go
+++ b/metal/datasource_metal_spot_market_request_test.go
@@ -52,7 +52,7 @@ func testDataSourceMetalSpotMarketRequestConfig_Basic(projSuffix string) string 
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-  name = "tfacc-spot_market_request-%s"
+  name = "tfacc-pro-spot_market_request-%s"
 }
 
 resource "metal_spot_market_request" "req" {
@@ -81,7 +81,7 @@ func testDataSourceMetalSpotMarketRequestConfig_Metro(projSuffix string) string 
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-  name = "tfacc-spot_market_request-%s"
+  name = "tfacc-pro-spot_market_request-%s"
 }
 
 resource "metal_spot_market_request" "req" {

--- a/metal/datasource_metal_vlan_test.go
+++ b/metal/datasource_metal_vlan_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func testAccCheckMetalDatasourceVlanConfig_ByVxlanFacility(projSuffix, fac, desc string) string {
+func testAccCheckMetalDatasourceVlanConfig_ByVxlanFacility(projSuffix, fac string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+    name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
-    facility = "%s"
-    description = "%s"
+    facility = "%[3]s"
+    description = "%[1]s-vlan foovlan"
 }
 
 data "metal_vlan" "dsvlan" {
@@ -28,7 +28,7 @@ data "metal_vlan" "dsvlan" {
     project_id = metal_vlan.foovlan.project_id
     vxlan = metal_vlan.foovlan.vxlan
 }
-`, projSuffix, fac, desc)
+`, tstResourcePrefix, projSuffix, fac)
 }
 
 func TestAccMetalDatasourceVlan_ByVxlanFacility(t *testing.T) {
@@ -41,7 +41,7 @@ func TestAccMetalDatasourceVlan_ByVxlanFacility(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanFacility(rs, fac, "testvlan"),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanFacility(rs, fac),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",
@@ -57,16 +57,16 @@ func TestAccMetalDatasourceVlan_ByVxlanFacility(t *testing.T) {
 	})
 }
 
-func testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(projSuffix, metro, desc string) string {
+func testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+    name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
-    metro = "%s"
-    description = "%s"
+    metro = "%[3]s"
+    description = "%[1]s-vlan foovlan"
     vxlan = 5
 }
 
@@ -79,6 +79,7 @@ data "metal_vlan" "dsvlan" {
 resource "metal_vlan" "barvlan" {
     project_id = metal_project.foobar.id
     metro = metal_vlan.foovlan.metro
+	description = "%[1]s-vlan barvlan"
     vxlan = 6
 }
 
@@ -87,12 +88,13 @@ data "metal_vlan" "bardsvlan" {
     project_id = metal_vlan.barvlan.project_id
     vxlan = metal_vlan.barvlan.vxlan
 }
-`, projSuffix, metro, desc)
+`, tstResourcePrefix, projSuffix, metro)
 }
 
 func TestAccMetalDatasourceVlan_ByVxlanMetro(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
+	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -100,7 +102,7 @@ func TestAccMetalDatasourceVlan_ByVxlanMetro(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(rs, metro, "testvlan"),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(rs, metro, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",
@@ -144,12 +146,12 @@ func testAccCheckMetalDatasourceVlanDestroyed(s *terraform.State) error {
 func testAccCheckMetalDatasourceVlanConfig_ByVlanId(projSuffix, metro, desc string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+    name = "%[1]-vlan-%s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
-    metro = "%s"
+    metro = "%[3]s"
     description = "%s"
     vxlan = 5
 }
@@ -157,12 +159,13 @@ resource "metal_vlan" "foovlan" {
 data "metal_vlan" "dsvlan" {
     vlan_id = metal_vlan.foovlan.id
 }
-`, projSuffix, metro, desc)
+`, tstResourcePrefix, projSuffix, metro)
 }
 
 func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
+	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -170,7 +173,7 @@ func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByVlanId(rs, metro, "testvlan"),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByVlanId(rs, metro, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",
@@ -189,13 +192,13 @@ func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 func testAccCheckMetalDatasourceVlanConfig_ByProjectId(projSuffix, metro, desc string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+    name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
-    metro = "%s"
-    description = "%s"
+    metro = "%[3]s"
+    description = "%[1]s-vlan foovlan"
     vxlan = 5
 }
 
@@ -208,6 +211,7 @@ data "metal_vlan" "dsvlan" {
 func TestAccMetalDatasourceVlan_ByProjectId(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
+	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -215,7 +219,7 @@ func TestAccMetalDatasourceVlan_ByProjectId(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByProjectId(rs, metro, "testvlan"),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByProjectId(rs, metro, description),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",

--- a/metal/datasource_metal_vlan_test.go
+++ b/metal/datasource_metal_vlan_test.go
@@ -14,7 +14,7 @@ import (
 func testAccCheckMetalDatasourceVlanConfig_ByVxlanFacility(projSuffix, fac string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "%[1]s-pro-%[2]s"
+    name = "%[1]s-pro-vlan-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
@@ -60,7 +60,7 @@ func TestAccMetalDatasourceVlan_ByVxlanFacility(t *testing.T) {
 func testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "%[1]s-pro-%[2]s"
+    name = "%[1]s-pro-vlan-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
@@ -145,7 +145,7 @@ func testAccCheckMetalDatasourceVlanDestroyed(s *terraform.State) error {
 func testAccCheckMetalDatasourceVlanConfig_ByVlanId(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "%[1]s-pro-%[2]s"
+    name = "%[1]s-pro-vlan-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
@@ -190,7 +190,7 @@ func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 func testAccCheckMetalDatasourceVlanConfig_ByProjectId(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "%[1]s-pro-%[2]s"
+    name = "%[1]s-pro-vlan-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {

--- a/metal/datasource_metal_vlan_test.go
+++ b/metal/datasource_metal_vlan_test.go
@@ -94,7 +94,6 @@ data "metal_vlan" "bardsvlan" {
 func TestAccMetalDatasourceVlan_ByVxlanMetro(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
-	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -102,7 +101,7 @@ func TestAccMetalDatasourceVlan_ByVxlanMetro(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(rs, metro, description),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByVxlanMetro(rs, metro),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",
@@ -143,16 +142,16 @@ func testAccCheckMetalDatasourceVlanDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMetalDatasourceVlanConfig_ByVlanId(projSuffix, metro, desc string) string {
+func testAccCheckMetalDatasourceVlanConfig_ByVlanId(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "%[1]-vlan-%s"
+    name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
     metro = "%[3]s"
-    description = "%s"
+    description = "%[1]s-vlan foovlan"
     vxlan = 5
 }
 
@@ -165,7 +164,6 @@ data "metal_vlan" "dsvlan" {
 func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
-	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -173,7 +171,7 @@ func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByVlanId(rs, metro, description),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByVlanId(rs, metro),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",
@@ -189,7 +187,7 @@ func TestAccMetalDatasourceVlan_ByVlanId(t *testing.T) {
 	})
 }
 
-func testAccCheckMetalDatasourceVlanConfig_ByProjectId(projSuffix, metro, desc string) string {
+func testAccCheckMetalDatasourceVlanConfig_ByProjectId(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
     name = "%[1]s-pro-%[2]s"
@@ -205,13 +203,12 @@ resource "metal_vlan" "foovlan" {
 data "metal_vlan" "dsvlan" {
     project_id = metal_vlan.foovlan.project_id
 }
-`, projSuffix, metro, desc)
+`, tstResourcePrefix, projSuffix, metro)
 }
 
 func TestAccMetalDatasourceVlan_ByProjectId(t *testing.T) {
 	rs := acctest.RandString(10)
 	metro := "sv"
-	description := fmt.Sprintf("%s-vlan", tstResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -219,7 +216,7 @@ func TestAccMetalDatasourceVlan_ByProjectId(t *testing.T) {
 		CheckDestroy: testAccCheckMetalDatasourceVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalDatasourceVlanConfig_ByProjectId(rs, metro, description),
+				Config: testAccCheckMetalDatasourceVlanConfig_ByProjectId(rs, metro),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"metal_vlan.foovlan", "vxlan",

--- a/metal/resource_metal_bgp_setup_test.go
+++ b/metal/resource_metal_bgp_setup_test.go
@@ -67,7 +67,7 @@ func testAccCheckMetalBGPSetupDestroy(s *terraform.State) error {
 func testAccCheckMetalBGPSetupConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-bgp_session-%s"
+    name = "tfacc-pro-bgp_session-%s"
 	bgp_config {
 		deployment_type = "local"
 		md5 = "C179c28c41a85b"

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -60,7 +60,7 @@ func testAccCheckMetalConnectionDestroy(s *terraform.State) error {
 func testAccMetalConnectionConfig_Shared(randstr string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "%[1]s-pro-%[2]s"
+	name = "%[1]s-pro-conn-%[2]s"
 }
 
 resource "metal_connection" "test" {
@@ -123,7 +123,7 @@ func TestAccMetalConnection_Shared(t *testing.T) {
 func testAccMetalConnectionConfig_Dedicated(randstr string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "%[1]s-pro-%[2]s"
+	name = "%[1]s-pro-conn-%[2]s"
 }
 
 // We use the project resource to get organization_id
@@ -188,7 +188,7 @@ func TestAccMetalConnection_Dedicated(t *testing.T) {
 func testAccMetalConnectionConfig_Tunnel(randstr string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "%[1]s-pro-%[2]s"
+	name = "%[1]s-pro-conn-%[2]s"
 }
 
 // We use the project resource to get organization_id internally

--- a/metal/resource_metal_connection_test.go
+++ b/metal/resource_metal_connection_test.go
@@ -59,20 +59,20 @@ func testAccCheckMetalConnectionDestroy(s *terraform.State) error {
 
 func testAccMetalConnectionConfig_Shared(randstr string) string {
 	return fmt.Sprintf(`
-        resource "metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+resource "metal_project" "test" {
+	name = "%[1]s-pro-%[2]s"
+}
 
-        resource "metal_connection" "test" {
-            name               = "tfacc-conn-%s"
-            project_id         = metal_project.test.id
-            type               = "shared"
-            redundancy         = "redundant"
-            metro              = "sv"
-			speed              = "50Mbps"
-			service_token_type = "a_side"
-        }`,
-		randstr, randstr)
+resource "metal_connection" "test" {
+	name               = "%[1]s-conn-%[2]s"
+	project_id         = metal_project.test.id
+	type               = "shared"
+	redundancy         = "redundant"
+	metro              = "sv"
+	speed              = "50Mbps"
+	service_token_type = "a_side"
+}
+`, tstResourcePrefix, randstr)
 }
 
 func TestAccMetalConnection_Shared(t *testing.T) {
@@ -122,29 +122,30 @@ func TestAccMetalConnection_Shared(t *testing.T) {
 
 func testAccMetalConnectionConfig_Dedicated(randstr string) string {
 	return fmt.Sprintf(`
-        resource "metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+resource "metal_project" "test" {
+	name = "%[1]s-pro-%[2]s"
+}
 
-        // We use the project resource to get organization_id
-        resource "metal_connection" "test" {
-            name            = "tfacc-conn-%s"
-            metro           = "sv"
-            organization_id = metal_project.test.organization_id
-            type            = "dedicated"
-            redundancy      = "redundant"
-			tags            = ["tfacc"]
-			speed           = "50Mbps"
-			mode            = "standard"
-        }`,
-		randstr, randstr)
+// We use the project resource to get organization_id
+resource "metal_connection" "test" {
+	name            = "%[1]s-conn-%[2]s"
+	metro           = "sv"
+	organization_id = metal_project.test.organization_id
+	type            = "dedicated"
+	redundancy      = "redundant"
+	tags            = ["%[1]s"]
+	speed           = "50Mbps"
+	mode            = "standard"
+}
+`, tstResourcePrefix, randstr)
 }
 
 func testDataSourceMetalConnectionConfig() string {
 	return `
-		data "metal_connection" "test" {
-            connection_id = metal_connection.test.id
-        }`
+data "metal_connection" "test" {
+	connection_id = metal_connection.test.id
+}
+`
 }
 
 func TestAccMetalConnection_Dedicated(t *testing.T) {
@@ -186,21 +187,21 @@ func TestAccMetalConnection_Dedicated(t *testing.T) {
 
 func testAccMetalConnectionConfig_Tunnel(randstr string) string {
 	return fmt.Sprintf(`
-        resource "metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+resource "metal_project" "test" {
+	name = "%[1]s-pro-%[2]s"
+}
 
-		// We use the project resource to get organization_id internally
-        resource "metal_connection" "test" {
-            name            = "tfacc-conn-%s"
-            project_id      = metal_project.test.id
-            metro           = "sv"
-            redundancy      = "redundant"
-            type            = "dedicated"
-            mode            = "tunnel"
-			speed           = "50Mbps"
-        }`,
-		randstr, randstr)
+// We use the project resource to get organization_id internally
+resource "metal_connection" "test" {
+	name            = "%[1]s-conn-%[2]s"
+	project_id      = metal_project.test.id
+	metro           = "sv"
+	redundancy      = "redundant"
+	type            = "dedicated"
+	mode            = "tunnel"
+	speed           = "50Mbps"
+}
+`, tstResourcePrefix, randstr)
 }
 
 func TestAccMetalConnection_Tunnel(t *testing.T) {

--- a/metal/resource_metal_device_test.go
+++ b/metal/resource_metal_device_test.go
@@ -473,7 +473,7 @@ func TestAccMetalDevice_importBasic(t *testing.T) {
 func testAccCheckMetalDeviceConfig_no_description(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -491,7 +491,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_reinstall(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -515,7 +515,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_varname(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -534,7 +534,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_varname_pxe(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -555,7 +555,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_metro(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -571,7 +571,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_minimal(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -585,7 +585,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_basic(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test" {
@@ -601,7 +601,7 @@ resource "metal_device" "test" {
 func testAccCheckMetalDeviceConfig_facility_list(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-  name = "tfacc-device-%s"
+  name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test"  {
@@ -618,7 +618,7 @@ resource "metal_device" "test"  {
 func testAccCheckMetalDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-  name = "tfacc-device-%s"
+  name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test_ipxe_script_url"  {
@@ -637,7 +637,7 @@ resource "metal_device" "test_ipxe_script_url"  {
 
 var testAccCheckMetalDeviceConfig_ipxe_conflict = `
 resource "metal_project" "test" {
-  name = "tfacc-device-%s"
+  name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test_ipxe_conflict" {
@@ -654,7 +654,7 @@ resource "metal_device" "test_ipxe_conflict" {
 
 var testAccCheckMetalDeviceConfig_ipxe_missing = `
 resource "metal_project" "test" {
-  name = "tfacc-device-%s"
+  name = "tfacc-pro-device-%s"
 }
 
 resource "metal_device" "test_ipxe_missing" {

--- a/metal/resource_metal_gateway_test.go
+++ b/metal/resource_metal_gateway_test.go
@@ -12,21 +12,21 @@ import (
 func testAccMetalGatewayConfig_PrivateIPv4() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-gateway-test"
+	name = "%[1]s-gateway-test"
 }
 
 resource "metal_vlan" "test" {
-    description = "test VLAN in SV"
-    metro       = "sv"
-    project_id  = metal_project.test.id
+	description = "%[1]s-vlan in SV"
+	metro       = "sv"
+	project_id  = metal_project.test.id
 }
 
 resource "metal_gateway" "test" {
-    project_id               = metal_project.test.id
-    vlan_id                  = metal_vlan.test.id
-    private_ipv4_subnet_size = 8
+	project_id               = metal_project.test.id
+	vlan_id                  = metal_vlan.test.id
+	private_ipv4_subnet_size = 8
 }
-`)
+`, tstResourcePrefix)
 }
 
 func TestAccMetalGateway_PrivateIPv4(t *testing.T) {
@@ -52,28 +52,29 @@ func TestAccMetalGateway_PrivateIPv4(t *testing.T) {
 func testAccMetalGatewayConfig_ExistingReservation() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-gateway-test"
+	name = "%[1]s-gateway-test"
 }
 
 resource "metal_vlan" "test" {
-    description = "test VLAN in SV"
-    metro       = "sv"
-    project_id  = metal_project.test.id
+	description = "%[1]s-vlan in SV"
+	metro       = "sv"
+	project_id  = metal_project.test.id
 }
 
 resource "metal_reserved_ip_block" "test" {
-    project_id = metal_project.test.id
-    metro      = "sv"
-    quantity   = 8
+	project_id = metal_project.test.id
+	metro      = "sv"
+	quantity   = 8
 }
 
 resource "metal_gateway" "test" {
-    project_id        = metal_project.test.id
-    vlan_id           = metal_vlan.test.id
-    ip_reservation_id = metal_reserved_ip_block.test.id
+	project_id        = metal_project.test.id
+	vlan_id           = metal_vlan.test.id
+	ip_reservation_id = metal_reserved_ip_block.test.id
 }
-`)
+`, tstResourcePrefix)
 }
+
 
 func TestAccMetalGateway_ExistingReservation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{

--- a/metal/resource_metal_gateway_test.go
+++ b/metal/resource_metal_gateway_test.go
@@ -75,7 +75,6 @@ resource "metal_gateway" "test" {
 `, tstResourcePrefix)
 }
 
-
 func TestAccMetalGateway_ExistingReservation(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/metal/resource_metal_gateway_test.go
+++ b/metal/resource_metal_gateway_test.go
@@ -12,7 +12,7 @@ import (
 func testAccMetalGatewayConfig_PrivateIPv4() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "%[1]s-gateway-test"
+	name = "%[1]s-pro-gateway-test"
 }
 
 resource "metal_vlan" "test" {
@@ -52,7 +52,7 @@ func TestAccMetalGateway_PrivateIPv4(t *testing.T) {
 func testAccMetalGatewayConfig_ExistingReservation() string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-	name = "%[1]s-gateway-test"
+	name = "%[1]s-pro-gateway-test"
 }
 
 resource "metal_vlan" "test" {

--- a/metal/resource_metal_ip_attachment_test.go
+++ b/metal/resource_metal_ip_attachment_test.go
@@ -56,7 +56,7 @@ func testAccCheckMetalIPAttachmentDestroy(s *terraform.State) error {
 func testAccCheckMetalIPAttachmentConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-ip_attachment-%s"
+    name = "tfacc-pro-ipattach-%s"
 }
 
 resource "metal_device" "test" {
@@ -112,7 +112,7 @@ func TestAccMetalIPAttachment_Metro(t *testing.T) {
 func testAccCheckMetalIPAttachmentConfig_Metro(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-ip_attachment-%s"
+    name = "tfacc-pro-ipattach-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/resource_metal_port_test.go
+++ b/metal/resource_metal_port_test.go
@@ -14,7 +14,7 @@ import (
 func confAccMetalPort_base(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-port-test-%s"
+    name = "tfacc-pro-port-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/resource_metal_port_test.go
+++ b/metal/resource_metal_port_test.go
@@ -18,18 +18,18 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  hostname         = "tfacc-metal-port-test"
-  plan             = "c3.medium.x86"
-  metro            = "da"
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${metal_project.test.id}"
+	hostname         = "tfacc-metal-port-test"
+	plan             = "c3.medium.x86"
+	metro            = "da"
+	operating_system = "ubuntu_16_04"
+	billing_cycle    = "hourly"
+	project_id       = "${metal_project.test.id}"
 }
 
 locals {
-  bond0_id = [for p in metal_device.test.ports: p.id if p.name == "bond0"][0]
-  eth1_id = [for p in metal_device.test.ports: p.id if p.name == "eth1"][0]
-  eth0_id = [for p in metal_device.test.ports: p.id if p.name == "eth0"][0]
+	bond0_id = [for p in metal_device.test.ports: p.id if p.name == "bond0"][0]
+	eth1_id = [for p in metal_device.test.ports: p.id if p.name == "eth1"][0]
+	eth0_id = [for p in metal_device.test.ports: p.id if p.name == "eth0"][0]
 }
 
 `, name)
@@ -40,11 +40,11 @@ func confAccMetalPort_L3(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  bonded = true
-  depends_on = [
-    metal_port.eth1,
-  ]
+	port_id = local.bond0_id
+	bonded = true
+	depends_on = [
+		metal_port.eth1,
+	]
 }
 
 resource "metal_port" "eth1" {
@@ -60,10 +60,10 @@ func confAccMetalPort_L2Bonded(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  layer2 = true
-  bonded = true
-  reset_on_delete = true
+	port_id = local.bond0_id
+	layer2 = true
+	bonded = true
+	reset_on_delete = true
 }
 
 `, confAccMetalPort_base(name))
@@ -74,10 +74,10 @@ func confAccMetalPort_L2Individual(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  layer2 = true
-  bonded = false
-  reset_on_delete = true
+	port_id = local.bond0_id
+	layer2 = true
+	bonded = false
+	reset_on_delete = true
 }
 
 `, confAccMetalPort_base(name))
@@ -88,18 +88,18 @@ func confAccMetalPort_HybridUnbonded(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  layer2 = false
-  bonded = true
-  depends_on = [
-    metal_port.eth1,
-  ]
+	port_id = local.bond0_id
+	layer2 = false
+	bonded = true
+	depends_on = [
+		metal_port.eth1,
+	]
 }
 
 resource "metal_port" "eth1" {
-  port_id = local.eth1_id
-  bonded = false
-  reset_on_delete = true
+	port_id = local.eth1_id
+	bonded = false
+	reset_on_delete = true
 }
 
 `, confAccMetalPort_base(name))
@@ -110,19 +110,19 @@ func confAccMetalPort_HybridBonded(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  layer2 = false
-  bonded = true
-  vlan_ids = [metal_vlan.test.id]
-  reset_on_delete = true
+	port_id = local.bond0_id
+	layer2 = false
+	bonded = true
+	vlan_ids = [metal_vlan.test.id]
+	reset_on_delete = true
 }
 
 resource "metal_vlan" "test" {
-  description = "test"
-  metro = "ny"
-  project_id = metal_project.test.id
+	description = "%s-vlan test"
+	metro = "ny"
+	project_id = metal_project.test.id
 }
-`, confAccMetalPort_base(name))
+`, confAccMetalPort_base(name), tstResourcePrefix)
 }
 
 func confAccMetalPort_HybridBondedVxlan(name string) string {
@@ -130,27 +130,27 @@ func confAccMetalPort_HybridBondedVxlan(name string) string {
 %s
 
 resource "metal_port" "bond0" {
-  port_id = local.bond0_id
-  layer2 = false
-  bonded = true
-  vxlan_ids = [metal_vlan.test1.vxlan, metal_vlan.test2.vxlan]
-  reset_on_delete = true
+	port_id = local.bond0_id
+	layer2 = false
+	bonded = true
+	vxlan_ids = [metal_vlan.test1.vxlan, metal_vlan.test2.vxlan]
+	reset_on_delete = true
 }
 
 resource "metal_vlan" "test1" {
-  description = "test1"
-  metro = "ny"
-  project_id = metal_project.test.id
-  vxlan = 1001
+	description = "%[2]s-vlan test1"
+	metro = "ny"
+	project_id = metal_project.test.id
+	vxlan = 1001
 }
 
 resource "metal_vlan" "test2" {
-  description = "test2"
-  metro = "ny"
-  project_id = metal_project.test.id
-  vxlan = 1002
+	description = "%[2]s-vlan test2"
+	metro = "ny"
+	project_id = metal_project.test.id
+	vxlan = 1002
 }
-`, confAccMetalPort_base(name))
+`, confAccMetalPort_base(name), tstResourcePrefix)
 }
 
 func TestAccMetalPort_HybridBondedVxlan(t *testing.T) {

--- a/metal/resource_metal_port_vlan_attachment_test.go
+++ b/metal/resource_metal_port_vlan_attachment_test.go
@@ -19,12 +19,12 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  hostname         = "tfacc-device-port-vlan-attachment-test"
-  plan             = "s1.large.x86"
-  facilities       = ["nrt1"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${metal_project.test.id}"
+	hostname         = "tfacc-device-port-vlan-attachment-test"
+	plan             = "s1.large.x86"
+	facilities       = ["nrt1"]
+	operating_system = "ubuntu_16_04"
+	billing_cycle    = "hourly"
+	project_id       = "${metal_project.test.id}"
 }
 `, name)
 }
@@ -34,35 +34,35 @@ func testAccCheckMetalPortVlanAttachmentConfig_L2Bonded_2(name string) string {
 %s
 
 resource "metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test1"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test2"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_device_network_type" "test" {
-  device_id = metal_device.test.id
-  type = "layer2-bonded"
+	device_id = metal_device.test.id
+	type = "layer2-bonded"
 }
 
 resource "metal_port_vlan_attachment" "test1" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test1.vxlan}"
-  port_name = "bond0"
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test1.vxlan}"
+	port_name = "bond0"
 }
 
 resource "metal_port_vlan_attachment" "test2" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test2.vxlan}"
-  port_name = "bond0"
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test2.vxlan}"
+	port_name = "bond0"
 }
 
-`, testAccCheckMetalPortVlanAttachmentConfig_L2Bonded_1(name))
+`, testAccCheckMetalPortVlanAttachmentConfig_L2Bonded_1(name), tstResourcePrefix)
 }
 
 func TestAccMetalPortVlanAttachment_L2Bonded(t *testing.T) {
@@ -104,12 +104,12 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  hostname         = "tfacc-vlan-l2i-test"
-  plan             = "s1.large.x86"
-  facilities       = ["nrt1"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${metal_project.test.id}"
+	hostname         = "tfacc-vlan-l2i-test"
+	plan             = "s1.large.x86"
+	facilities       = ["nrt1"]
+	operating_system = "ubuntu_16_04"
+	billing_cycle    = "hourly"
+	project_id       = "${metal_project.test.id}"
 }
 `, name)
 }
@@ -119,35 +119,35 @@ func testAccCheckMetalPortVlanAttachmentConfig_L2Individual_2(name string) strin
 %s
 
 resource "metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test1"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test2"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_device_network_type" "test" {
-  device_id = metal_device.test.id
-  type = "layer2-individual"
+	device_id = metal_device.test.id
+	type = "layer2-individual"
 }
 
 resource "metal_port_vlan_attachment" "test1" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test1.vxlan}"
-  port_name = "eth1"
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test1.vxlan}"
+	port_name = "eth1"
 }
 
 resource "metal_port_vlan_attachment" "test2" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test2.vxlan}"
-  port_name = "eth1"
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test2.vxlan}"
+	port_name = "eth1"
 }
 
-`, testAccCheckMetalPortVlanAttachmentConfig_L2Individual_1(name))
+`, testAccCheckMetalPortVlanAttachmentConfig_L2Individual_1(name), tstResourcePrefix)
 }
 
 func TestAccMetalPortVlanAttachment_L2Individual(t *testing.T) {
@@ -191,12 +191,12 @@ resource "metal_project" "test" {
 }
 
 resource "metal_device" "test" {
-  hostname         = "tfacc-device-hybrid-test"
-  plan             = "n2.xlarge.x86"
-  facilities       = ["dfw2"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${metal_project.test.id}"
+	hostname         = "tfacc-device-hybrid-test"
+	plan             = "n2.xlarge.x86"
+	facilities       = ["dfw2"]
+	operating_system = "ubuntu_16_04"
+	billing_cycle    = "hourly"
+	project_id       = "${metal_project.test.id}"
 }`, name)
 }
 
@@ -205,22 +205,23 @@ func testAccCheckMetalPortVlanAttachmentConfig_Hybrid_2(name string) string {
 %s 
 
 resource "metal_device_network_type" "test" {
-  device_id = metal_device.test.id
-  type = "hybrid"
+	device_id = metal_device.test.id
+	type = "hybrid"
 }
 
 resource "metal_vlan" "test" {
-  description = "test vlan"
-  facility    = "dfw2"
-  project_id  = "${metal_project.test.id}"
+	description = "%s-vlan test"
+	facility    = "dfw2"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_port_vlan_attachment" "test" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test.vxlan}"
-  port_name = "eth1"
-  force_bond = false
-}`, testAccCheckMetalPortVlanAttachmentConfig_Hybrid_1(name))
+	device_id  = metal_device_network_type.test.id
+	vlan_vnid  = "${metal_vlan.test.vxlan}"
+	port_name  = "eth1"
+	force_bond = false
+}
+`, testAccCheckMetalPortVlanAttachmentConfig_Hybrid_1(name), tstResourcePrefix)
 }
 
 func TestAccMetalPortVlanAttachment_HybridBasic(t *testing.T) {
@@ -275,23 +276,24 @@ func testAccCheckMetalPortVlanAttachmentConfig_HybridMultipleVlans_2(name string
 %s
 
 resource "metal_vlan" "test" {
-  count       = 3
-  description = "test VLAN"
-  facility    = "nrt1"
-  project_id  = metal_project.test.id
+	count       = 3
+	description = "%s-vlan test"
+	facility    = "nrt1"
+	project_id  = metal_project.test.id
 }
 
 resource "metal_device_network_type" "test" {
-  device_id = metal_device.test.id
-  type = "hybrid"
+	device_id = metal_device.test.id
+	type      = "hybrid"
 }
 
 resource "metal_port_vlan_attachment" "test" {
-  count     = length(metal_vlan.test)
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = metal_vlan.test[count.index].vxlan
-  port_name = "eth1"
-}`, testAccCheckMetalPortVlanAttachmentConfig_HybridMultipleVlans_1(name))
+	count     = length(metal_vlan.test)
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = metal_vlan.test[count.index].vxlan
+	port_name = "eth1"
+}
+`, testAccCheckMetalPortVlanAttachmentConfig_HybridMultipleVlans_1(name), tstResourcePrefix)
 }
 
 func TestAccMetalPortVlanAttachment_HybridMultipleVlans(t *testing.T) {
@@ -389,37 +391,37 @@ func testAccCheckMetalPortVlanAttachmentConfig_L2Native_2(name string) string {
 %s
 
 resource "metal_vlan" "test1" {
-  description = "test VLAN 1"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test1"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_vlan" "test2" {
-  description = "test VLAN 2"
-  facility    = "nrt1"
-  project_id  = "${metal_project.test.id}"
+	description = "%[2]s-vlan test2"
+	facility    = "nrt1"
+	project_id  = "${metal_project.test.id}"
 }
 
 resource "metal_device_network_type" "test" {
-  device_id = metal_device.test.id
-  type = "layer2-individual"
+	device_id = metal_device.test.id
+	type = "layer2-individual"
 }
 
 resource "metal_port_vlan_attachment" "test1" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test1.vxlan}"
-  port_name = "eth1"
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test1.vxlan}"
+	port_name = "eth1"
 }
 
 resource "metal_port_vlan_attachment" "test2" {
-  device_id = metal_device_network_type.test.id
-  vlan_vnid = "${metal_vlan.test2.vxlan}"
-  native    = true
-  port_name = "eth1"
-  depends_on = ["metal_port_vlan_attachment.test1"]
+	device_id = metal_device_network_type.test.id
+	vlan_vnid = "${metal_vlan.test2.vxlan}"
+	native    = true
+	port_name = "eth1"
+	depends_on = ["metal_port_vlan_attachment.test1"]
 }
 
-`, testAccCheckMetalPortVlanAttachmentConfig_L2Native_1(name))
+`, testAccCheckMetalPortVlanAttachmentConfig_L2Native_1(name), tstResourcePrefix)
 }
 
 func TestAccMetalPortVlanAttachment_L2Native(t *testing.T) {

--- a/metal/resource_metal_port_vlan_attachment_test.go
+++ b/metal/resource_metal_port_vlan_attachment_test.go
@@ -15,7 +15,7 @@ import (
 func testAccCheckMetalPortVlanAttachmentConfig_L2Bonded_1(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-port_vlan_attachment-%s"
+    name = "tfacc-pro-port_vlan_attachment-%s"
 }
 
 resource "metal_device" "test" {
@@ -100,7 +100,7 @@ func TestAccMetalPortVlanAttachment_L2Bonded(t *testing.T) {
 func testAccCheckMetalPortVlanAttachmentConfig_L2Individual_1(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-port_vlan_attachment-%s"
+    name = "tfacc-pro-port_vlan_attachment-%s"
 }
 
 resource "metal_device" "test" {
@@ -187,7 +187,7 @@ func TestAccMetalPortVlanAttachment_L2Individual(t *testing.T) {
 func testAccCheckMetalPortVlanAttachmentConfig_Hybrid_1(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-port_vlan_attachment-%s"
+    name = "tfacc-pro-port_vlan_attachment-%s"
 }
 
 resource "metal_device" "test" {
@@ -258,7 +258,7 @@ func TestAccMetalPortVlanAttachment_HybridBasic(t *testing.T) {
 func testAccCheckMetalPortVlanAttachmentConfig_HybridMultipleVlans_1(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-  name = "tfacc-port_vlan_attachment-%s"
+  name = "tfacc-pro-port_vlan_attachment-%s"
 }
 
 resource "metal_device" "test" {
@@ -373,7 +373,7 @@ func testAccCheckMetalPortVlanAttachmentDestroy(s *terraform.State) error {
 func testAccCheckMetalPortVlanAttachmentConfig_L2Native_1(name string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-port_vlan_attachment-%s"
+    name = "tfacc-pro-port_vlan_attachment-%s"
 }
 
 resource "metal_device" "test" {

--- a/metal/resource_metal_project_api_key_test.go
+++ b/metal/resource_metal_project_api_key_test.go
@@ -26,7 +26,7 @@ func testAccMetalProjectAPIKeyConfig_Basic() string {
 	return fmt.Sprintf(`
 
 resource "metal_project" "test" {
-    name = "tfacc-project-key-test"
+    name = "tfacc-pro-key-test"
 }
 
 resource "metal_project_api_key" "test" {

--- a/metal/resource_metal_project_ssh_key_test.go
+++ b/metal/resource_metal_project_ssh_key_test.go
@@ -13,7 +13,7 @@ import (
 func metalProjectSSHKeyConfig_Basic(name, publicSshKey string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-project_ssh_key-%s"
+    name = "tfacc-pro-project_ssh_key-%s"
 }
 
 resource "metal_project_ssh_key" "test" {

--- a/metal/resource_metal_virtual_circuit_test.go
+++ b/metal/resource_metal_virtual_circuit_test.go
@@ -77,6 +77,7 @@ func testAccCheckMetalVirtualCircuitDestroy(s *terraform.State) error {
 func testAccMetalVirtualCircuitConfig_Dedicated(randstr string, randint int) string {
 	// Dedicated connection in DA metro
 	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
+
 	return fmt.Sprintf(`
 data "metal_connection" "test" {
 	connection_id = "%[1]s"

--- a/metal/resource_metal_virtual_circuit_test.go
+++ b/metal/resource_metal_virtual_circuit_test.go
@@ -41,7 +41,7 @@ func testSweepVirtualCircuits(region string) error {
 		for _, conn := range conns {
 			for _, port := range conn.Ports {
 				for _, vc := range port.VirtualCircuits {
-					if strings.HasPrefix(vc.Name, "tfacc-") {
+					if strings.HasPrefix(vc.Name, "tfacc-vc") {
 						vcs[vc.ID] = &vc
 					}
 				}
@@ -78,27 +78,30 @@ func testAccMetalVirtualCircuitConfig_Dedicated(randstr string, randint int) str
 	// Dedicated connection in DA metro
 	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
 	return fmt.Sprintf(`
-        data "metal_connection" "test" {
-			connection_id = "%s"
-		}
+data "metal_connection" "test" {
+	connection_id = "%[1]s"
+}
 
-		resource "metal_project" "test" {
-            name = "tfacc-conn-pro-%s"
-        }
+resource "metal_project" "test" {
+	name = "%[4]s-pro-%[2]s"
+}
 
-        resource "metal_vlan" "test" {
-            project_id = metal_project.test.id
-            metro      = "da"
-        }
+resource "metal_vlan" "test" {
+	project_id  = metal_project.test.id
+	metro       = "da"
+	description = "%[4]s-vlan test"
+}
 
-        resource "metal_virtual_circuit" "test" {
-            connection_id = data.metal_connection.test.id
-            project_id = metal_project.test.id
-            port_id = data.metal_connection.test.ports[0].id
-            vlan_id = metal_vlan.test.id
-            nni_vlan = %d
-        }`,
-		testConnection, randstr, randint)
+resource "metal_virtual_circuit" "test" {
+	name = "%[4]s-vc-%[2]s"
+	description = "%[4]s-vc-%[2]s"
+	connection_id = data.metal_connection.test.id
+	project_id = metal_project.test.id
+	port_id = data.metal_connection.test.ports[0].id
+	vlan_id = metal_vlan.test.id
+	nni_vlan = %[3]d
+}
+`, testConnection, randstr, randint, tstResourcePrefix)
 }
 
 func TestAccMetalVirtualCircuit_Dedicated(t *testing.T) {

--- a/metal/resource_metal_virtual_circuit_test.go
+++ b/metal/resource_metal_virtual_circuit_test.go
@@ -83,7 +83,7 @@ data "metal_connection" "test" {
 }
 
 resource "metal_project" "test" {
-	name = "%[4]s-pro-%[2]s"
+	name = "%[4]s-pro-vc-%[2]s"
 }
 
 resource "metal_vlan" "test" {

--- a/metal/resource_metal_vlan_test.go
+++ b/metal/resource_metal_vlan_test.go
@@ -60,19 +60,19 @@ func testSweepVlans(region string) error {
 	return nil
 }
 
-func testAccCheckMetalVlanConfig_metro(projSuffix, metro, desc string) string {
+func testAccCheckMetalVlanConfig_metro(projSuffix, metro string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+	name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
     project_id = metal_project.foobar.id
-    metro = "%s"
-    description = "%s"
+    metro = "%[3]s"
+    description = "%[1]s-vlan foovlan"
     vxlan = 5
 }
-`, projSuffix, metro, desc)
+`, tstResourcePrefix, projSuffix, metro)
 }
 
 func TestAccMetalVlan_Metro(t *testing.T) {
@@ -85,7 +85,7 @@ func TestAccMetalVlan_Metro(t *testing.T) {
 		CheckDestroy: testAccCheckMetalVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalVlanConfig_metro(rs, metro, "tfacc-vlan"),
+				Config: testAccCheckMetalVlanConfig_metro(rs, metro),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"metal_vlan.foovlan", "metro", metro),
@@ -108,7 +108,7 @@ func TestAccMetalVlan_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckMetalVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalVlanConfig_var(rs, fac, "testvlan"),
+				Config: testAccCheckMetalVlanConfig_var(rs, fac),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalVlanExists("metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
@@ -162,18 +162,18 @@ func testAccCheckMetalVlanDestroyed(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckMetalVlanConfig_var(projSuffix, facility, desc string) string {
+func testAccCheckMetalVlanConfig_var(projSuffix, fac string) string {
 	return fmt.Sprintf(`
 resource "metal_project" "foobar" {
-    name = "tfacc-vlan-%s"
+	name = "%[1]s-pro-%[2]s"
 }
 
 resource "metal_vlan" "foovlan" {
-    project_id = "${metal_project.foobar.id}"
-    facility = "%s"
-    description = "%s"
+    project_id  = "${metal_project.foobar.id}"
+    facility    = "%[3]s"
+    description = "%[1]s-vlan foovlan"
 }
-`, projSuffix, facility, desc)
+`, tstResourcePrefix, projSuffix, fac)
 }
 
 func TestAccMetalVlan_importBasic(t *testing.T) {
@@ -186,7 +186,7 @@ func TestAccMetalVlan_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckMetalVlanDestroyed,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckMetalVlanConfig_var(rs, fac, "testvlan"),
+				Config: testAccCheckMetalVlanConfig_var(rs, fac),
 			},
 			{
 				ResourceName:      "metal_vlan.foovlan",

--- a/metal/resource_metal_vlan_test.go
+++ b/metal/resource_metal_vlan_test.go
@@ -112,7 +112,7 @@ func TestAccMetalVlan_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMetalVlanExists("metal_vlan.foovlan", &vlan),
 					resource.TestCheckResourceAttr(
-						"metal_vlan.foovlan", "description", "testvlan"),
+						"metal_vlan.foovlan", "description", "tfacc-vlan foovlan"),
 					resource.TestCheckResourceAttr(
 						"metal_vlan.foovlan", "facility", fac),
 				),

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -386,7 +386,7 @@ func testAccMetalVRFConfig_withGateway(r int) string {
 	return testAccMetalVRFConfig_withIPReservations(r) + fmt.Sprintf(`
 
 resource "metal_vlan" "test" {
-	description = "tfacc-vlan-vrf"
+	description = "%s-vlan vrf"
 	metro       = "%s"
 	project_id  = metal_project.test.id
 }
@@ -396,7 +396,7 @@ resource "metal_gateway" "test" {
     vlan_id           = metal_vlan.test.id
     ip_reservation_id = metal_reserved_ip_block.test.id
 }
-`, testMetro)
+`, tstResourcePrefix, testMetro)
 }
 
 func testAccMetalVRFConfig_withVC(r, nniVlan int) string {
@@ -405,23 +405,23 @@ func testAccMetalVRFConfig_withVC(r, nniVlan int) string {
 	return testAccMetalVRFConfig_withIPRanges(r) + fmt.Sprintf(`
 
 	data "metal_connection" "test" {
-		connection_id = "%s"
+		connection_id = "%[1]s"
 	}
 
 	resource "metal_virtual_circuit" "test" {
-		name = "tfacc-vc-%d"
-		description = "tfacc-vc-%d"
+		name = "%[4]s-vc-%[2]d"
+		description = "%[4]s-vc-%[2]d"
 		connection_id = data.metal_connection.test.id
 		project_id = metal_project.test.id
 		port_id = data.metal_connection.test.ports[0].id
-		nni_vlan = %d
+		nni_vlan = %[3]d
 		vrf_id = metal_vrf.test.id
 		peer_asn = 65530
 		subnet = "192.168.100.16/31"
 		metal_ip = "192.168.100.16"
 		customer_ip = "192.168.100.17"
 	}
-	`, testConnection, r, r, nniVlan)
+	`, testConnection, r, nniVlan, tstResourcePrefix)
 }
 
 func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
@@ -433,18 +433,18 @@ func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
 	}
 
 	resource "metal_virtual_circuit" "test" {
-		name = "tfacc-vc-%d"
-		description = "tfacc-vc-%d"
+		name = "%[4]s-vc-%[2]d"
+		description = "%[4]s-vc-%[2]d"
 		connection_id = data.metal_connection.test.id
 		project_id = metal_project.test.id
 		port_id = data.metal_connection.test.ports[0].id
-		nni_vlan = %d
+		nni_vlan = %[3]d
 		vrf_id = metal_vrf.test.id
 		peer_asn = 65530
 		subnet = "192.168.100.16/31"
 		metal_ip = "192.168.100.16"
 		customer_ip = "192.168.100.17"
-	}`, testConnection, r, r, nniVlan)
+	}`, testConnection, r, nniVlan, tstResourcePrefix)
 }
 
 func testAccMetalVRFConfig_withConnection(r int) string {
@@ -452,11 +452,11 @@ func testAccMetalVRFConfig_withConnection(r int) string {
 	return testAccMetalVRFConfig_basic(r) + fmt.Sprintf(`
 
 	resource "metal_connection" "test" {
-		name            = "tfacc-conn-%d"
+		name            = "%s-conn-%d"
 		organization_id = metal_project.foobar.organization_id
 		project_id      = metal_project.foobar.id
 		metro           = "%s"
 		redundancy      = "redundant"
 		type            = "shared"
-	}`, r, testMetro)
+	}`, tstResourcePrefix, r, testMetro)
 }

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -335,7 +335,7 @@ func testAccMetalVRFConfig_basic(r int) string {
 
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-vrfs-%d"
+    name = "tfacc-pro-%d"
 }
 
 resource "metal_vrf" "test" {
@@ -350,7 +350,7 @@ func testAccMetalVRFConfig_withIPRanges(r int) string {
 
 	return fmt.Sprintf(`
 resource "metal_project" "test" {
-    name = "tfacc-vrfs-%d"
+    name = "tfacc-pro-%d"
 }
 
 resource "metal_vrf" "test" {
@@ -429,7 +429,7 @@ func testAccMetalVRFConfig_withVCGateway(r, nniVlan int) string {
 	testConnection := os.Getenv(metalDedicatedConnIDEnvVar)
 	return testAccMetalVRFConfig_withGateway(r) + fmt.Sprintf(`
 	data "metal_connection" "test" {
-		connection_id = "%s"
+		connection_id = "%[1]s"
 	}
 
 	resource "metal_virtual_circuit" "test" {

--- a/metal/resource_metal_vrf_test.go
+++ b/metal/resource_metal_vrf_test.go
@@ -169,9 +169,9 @@ func TestAccMetalVRF_withIPReservations(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName:      "metal_reserved_ip_block.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "metal_reserved_ip_block.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"wait_for_state"},
 			},
 		},


### PR DESCRIPTION
To remove projects all other resources that belong to that project must be removed first. There was some old projects not removed with VLANs on them

Sweeper for VLANs uses VLAN description to identify which must be deleted. To make it work ,all them must have same prefix, but some had no description or they were using a random strings. Same happens with virtual circuits

In this PR all descriptions of VLAN resources, and names of virtual circuits created in tests have been modified to have `tfacc` prefix

fix #233 