### PR TITLE
added warning message in all docs to notice provider depreaction

### DIFF
--- a/docs/data-sources/connection.md
+++ b/docs/data-sources/connection.md
@@ -5,7 +5,9 @@ description: |-
   Retrieve Equinix Fabric Connection
 ---
 
-# metal\_connection
+# metal_connection (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_connection`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_connection) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_connection`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to retrieve a connection resource from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 
@@ -13,7 +15,7 @@ Use this data source to retrieve a connection resource from [Equinix Fabric - so
 
 ```hcl
 data "metal_connection" "example" {
-  connection_id     = "4347e805-eb46-4699-9eb9-5c116e6a017d"
+  connection_id     = "4347e805-eb46-4699-9eb9-5c116e6a017d" 
 }
 ```
 

--- a/docs/data-sources/device.md
+++ b/docs/data-sources/device.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal device datasource. This can be used to read existing devices.
 ---
 
-# metal_device
+# metal_device (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_device`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_device) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_device`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal device datasource.
 

--- a/docs/data-sources/device_bgp_neighbors.md
+++ b/docs/data-sources/device_bgp_neighbors.md
@@ -5,7 +5,9 @@ description: |-
   Provides a datasource for listing BGP neighbors of an Equinix Metal device
 ---
 
-# metal_device_bgp_neighbors
+# metal_device_bgp_neighbors (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_device_bgp_neighbors`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_device_bgp_neighbors) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_device_bgp_neighbors`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this datasource to retrieve list of BGP neighbors of a device in the Equinix Metal host.
 

--- a/docs/data-sources/facility.md
+++ b/docs/data-sources/facility.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal facility datasource. This can be used to read facilities.
 ---
 
-# metal_facility
+# metal_facility (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_facility`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_facility) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_facility`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal facility datasource.
 

--- a/docs/data-sources/gateway.md
+++ b/docs/data-sources/gateway.md
@@ -5,7 +5,9 @@ description: |-
   Retrieve Equinix Metal Gateways
 ---
 
-# metal\_gateway
+# metal_gateway (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_gateway`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_gateway) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_gateway`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this datasource to retrieve Metal Gateway resources in Equinix Metal.
 

--- a/docs/data-sources/hardware_reservation.md
+++ b/docs/data-sources/hardware_reservation.md
@@ -5,7 +5,9 @@ description: |-
   Retrieve Equinix Metal Hardware Reservation
 ---
 
-# metal_hardware_reservation
+# metal_hardware_reservation (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_hardware_reservation`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_hardware_reservation) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_hardware_reservation`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to retrieve a [hardware reservation resource from Equinix Metal](https://metal.equinix.com/developers/docs/deploy/reserved/).
 

--- a/docs/data-sources/ip_block_ranges.md
+++ b/docs/data-sources/ip_block_ranges.md
@@ -5,7 +5,9 @@ description: |-
   List IP address ranges allocated to a project
 ---
 
-# metal\_ip\_block\_ranges
+# metal_ip_block_ranges (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_ip_block_ranges`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_ip_block_ranges) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_ip_block_ranges`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this datasource to get CIDR expressions for allocated IP blocks of all the types in a project, optionally filtered by facility or metro.
 

--- a/docs/data-sources/metro.md
+++ b/docs/data-sources/metro.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal metro datasource. This can be used to read metros.
 ---
 
-# metal_metro
+# metal_metro (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_metro`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_metro) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_metro`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal metro datasource.
 

--- a/docs/data-sources/operating_system.md
+++ b/docs/data-sources/operating_system.md
@@ -5,7 +5,9 @@ description: |-
   Get an Equinix Metal operating system image
 ---
 
-# metal\_operating\_system
+# metal_operating_system (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_operating_system`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_operating_system) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_operating_system`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to get Equinix Metal Operating System image.
 

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Organization datasource. This can be used to read existing Organizations.
 ---
 
-# metal_organization
+# metal_organization (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_organization`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_organization) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_organization`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal organization datasource.
 

--- a/docs/data-sources/plans.md
+++ b/docs/data-sources/plans.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal plans datasource. This can be used to find plans that meet a filter criteria.
 ---
 
-# metal_plans
+# metal_plans (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_plans`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_plans) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_plans`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal plans datasource. This can be used to find plans that meet a filter criteria.
 

--- a/docs/data-sources/port.md
+++ b/docs/data-sources/port.md
@@ -5,7 +5,9 @@ description: |-
   Fetch device ports
 ---
 
-# metal_port
+# metal_port (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_port`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_port) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_port`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to read ports of existing devices. You can read port by either its UUID, or by a device UUID and port name.
 

--- a/docs/data-sources/precreated_ip_block.md
+++ b/docs/data-sources/precreated_ip_block.md
@@ -5,7 +5,9 @@ description: |-
   Load automatically created IP blocks from your Equinix Metal project
 ---
 
-# metal\_precreated\_ip\_block
+# metal_precreated_ip_block (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_precreated_ip_block`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_precreated_ip_block) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_precreated_ip_block`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Equinix Metal.
 You can then use the cidrsubnet TF builtin function to derive subnets.

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Project datasource.
 ---
 
-# metal\_project
+# metal_project (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_project`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_project) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_project`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this datasource to retrieve attributes of the Project API resource.
 

--- a/docs/data-sources/project_ssh_key.md
+++ b/docs/data-sources/project_ssh_key.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Project SSH Key datasource.
 ---
 
-# metal\_project\_ssh\_key
+# metal_project_ssh_key (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_project_ssh_key`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_project_ssh_key) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_project_ssh_key`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this datasource to retrieve attributes of a Project SSH Key API resource.
 

--- a/docs/data-sources/reserved_ip_block.md
+++ b/docs/data-sources/reserved_ip_block.md
@@ -5,7 +5,9 @@ description: |-
 Look up an IP address block
 ---
 
-# metal\_reserved\_ip\_block
+# metal_reserved_ip_block (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_reserved_ip_block`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_reserved_ip_block) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_reserved_ip_block`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to find IP address blocks in Equinix Metal. You can use IP address or a block ID for lookup.
 

--- a/docs/data-sources/spot_market_price.md
+++ b/docs/data-sources/spot_market_price.md
@@ -5,7 +5,9 @@ description: |-
   Get an Equinix Metal Spot Market Price
 ---
 
-# metal\_operating\_system
+# metal_operating_system (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_operating_system`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_operating_system) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_operating_system`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to get Equinix Metal Spot Market Price for a plan.
 

--- a/docs/data-sources/spot_market_request.md
+++ b/docs/data-sources/spot_market_request.md
@@ -5,7 +5,9 @@ description: |-
   Provides a datasource for existing Spot Market Requests in the Equinix Metal host.
 ---
 
-# metal_spot_market_request
+# metal_spot_market_request (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_spot_market_request`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_spot_market_request) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_spot_market_request`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
 

--- a/docs/data-sources/virtual_circuit.md
+++ b/docs/data-sources/virtual_circuit.md
@@ -5,7 +5,9 @@ description: |-
   Retrieve Equinix Fabric Virtual Circuit
 ---
 
-# metal_virtual_circuit
+# metal_virtual_circuit (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_virtual_circuit`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_virtual_circuit) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_virtual_circuit`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this data source to retrieve a virtual circuit resource from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 

--- a/docs/data-sources/vlan.md
+++ b/docs/data-sources/vlan.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Virtual Network datasource. This can be used to read the attributes of existing VLANs.
 ---
 
-# metal_vlan
+# metal_vlan (Data Source)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_vlan`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_vlan) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_vlan`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal Virtual Network datasource. VLANs data sources can be
 searched by VLAN UUID, or project UUID and vxlan number.

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -5,5 +5,6 @@ description: |-
   (Removed) Provides an Equinix Metal Block Storage Volume Datasource.
 ---
 
-Datasource `metal_volume` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
+Datasource `metal_volume` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.

--- a/docs/data-sources/vrf.md
+++ b/docs/data-sources/vrf.md
@@ -7,6 +7,8 @@ description: |-
 
 # metal_virtual_circuit (Data Source)
 
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_virtual_circuit`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/data-sources/equinix_metal_virtual_circuit) data source from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_virtual_circuit`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
+
 Use this data source to retrieve a VRF resource.
 
 ~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.

--- a/docs/guides/migration_guide_facilities_to_metros_devices.md
+++ b/docs/guides/migration_guide_facilities_to_metros_devices.md
@@ -6,6 +6,8 @@ description: |-
 
 # Metros vs. Facilities
 
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
+
 In April 2021, Equinix Metal rolled out a new location concept - [metros](https://feedback.equinixmetal.com/changelog/new-metros-feature-live). A metro is an Equinix-wide concept for data centers which are grouped together geographically. Data centers within a metro share capacity and networking features. You can read more about metros at https://metal.equinix.com/developers/docs/locations/metros/.
 
 Before the introduction of metros, resources were deployed to a single `facility` location.  When provisioning `metal_device` resources, the facility could be chosen by Equinix Metal with a user-supplied list of `facilities`, or a wildcard `any` facility.  The individual facility locations use a code like "sv15" or "ny5". Metros group facilities. For example, metro "sv" contains the "sv15" facility, among others. If you specify a metro when creating a resource, it will be deployed to one of the facilities in the metro group. You can then find the deployed facility using a read-only attribute of the resource (e.g. `deployed_facility` for `metal_device` resources).

--- a/docs/guides/migration_guide_packet.md
+++ b/docs/guides/migration_guide_packet.md
@@ -6,6 +6,8 @@ description: |-
 
 # Migrating from packethost/packet to equinix/metal
 
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
+
 Packet is now Equinix Metal, and the name of the Terraform provider changed too. This (terraform-provider-metal, provider equinix/metal) is the current provider for Equinix Metal.
 
 If you've been using terraform-provider-packet, and you want to use a newer provider version to manage resources in Equinix Metal, you will need to change the references in you HCL files. You can just change the names of the resources, e.g. from `packet_device` to `metal_device`. That should work, but it will cause the `packet_device` to be destroyed and new `metal_device` to be created instead. Re-creation of the resources might be undesirable, and this guide shows how to migrate to metal_ resources without the re-creation.

--- a/docs/guides/network_types.md
+++ b/docs/guides/network_types.md
@@ -4,8 +4,9 @@ description: |-
   Use port bonding, address assignments, and VLAN attachments to change the device network type from Layer-3, to Layer-2, to Hybrid.
 ---
 
-
 # Network types
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Server network types, such as Layer-2, Layer-3, and Hybrid may be familiar to users of the Equinix Metal Portal. In the Portal, you can toggle the network type with a click of the UI. To take advantage of these features in Terraform, which closely follows the Equinix Metal API, it is important to understand that the network type is a composite string value determined by one or more port bonding, addressing, and VLAN attachment configurations. To change the network type, you must change these underlying properties of the port(s).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 # Equinix Metal Provider
 
-[Packet is now Equinix Metal!](https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/)
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated (End-of-Life scheduled for July 1, 2023) meaning that this software is only supported or maintained by Equinix Metal and its community in a case-by-case basis. The [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) has full support for existing Terraform managed Metal resources once Terraform configuration and state are adapted. The Equinix provider manages resources including Network Edge and Fabric in addition to Metal. [Please review the Metal to Equinix provider migration guide](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_equinix_metal). A guide is also available for [migrating from the Packet provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_packet).
 
 The Equinix Metal (`metal`) provider is used to interact with the resources supported by [Equinix Metal](https://metal.equinix.com/).
 The provider needs to be configured with the proper credentials before it can be used.

--- a/docs/resources/bgp_session.md
+++ b/docs/resources/bgp_session.md
@@ -5,7 +5,9 @@ description: |-
   BGP session in Equinix Metal Host
 ---
 
-# metal_bgp_session
+# metal_bgp_session (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_bgp_session`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_bgp_session) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_bgp_session`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to manage BGP sessions in Equinix Metal Host. Refer to [Equinix Metal BGP documentation](https://metal.equinix.com/developers/docs/networking/local-global-bgp/) for more details.
 

--- a/docs/resources/connection.md
+++ b/docs/resources/connection.md
@@ -5,7 +5,9 @@ description: |-
   Request/Create Equinix Fabric Connection
 ---
 
-# metal\_connection
+# metal_connection (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_connection`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_connection) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_connection`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to request of create an Interconnection from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/)
 

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal device resource. This can be used to create, modify, and delete devices.
 ---
 
-# metal_device
+# metal_device (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_device`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_device`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal device resource. This can be used to create,
 modify, and delete devices.

--- a/docs/resources/device_network_type.md
+++ b/docs/resources/device_network_type.md
@@ -6,7 +6,9 @@ description: |-
   Provides a resource to manage network type of Equinix Metal devices.
 ---
 
-# metal_device_network_type
+# metal_device_network_type (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_device_network_type`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_device_network_type) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_device_network_type`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 This resource controls network type of Equinix Metal devices.
 

--- a/docs/resources/gateway.md
+++ b/docs/resources/gateway.md
@@ -5,7 +5,9 @@ description: |-
   Create Equinix Metal Gateways
 ---
 
-# metal\_gateway
+# metal_gateway (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_gateway`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_gateway) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_gateway`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to create Metal Gateway resources in Equinix Metal.
 

--- a/docs/resources/ip_attachment.md
+++ b/docs/resources/ip_attachment.md
@@ -5,7 +5,9 @@ description: |-
   Provides a Resource for Attaching IP Subnets from a Reserved Block to a Device
 ---
 
-# metal\_ip\_attachment
+# metal_ip_attachment (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_ip_attachment`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_ip_attachment) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_ip_attachment`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to attach elastic IP subnets to devices.
 

--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Organization resource.
 ---
 
-# metal\_organization
+# metal_organization (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_organization`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_organization) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_organization`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to manage organization resource in Equinix Metal.
 

--- a/docs/resources/port.md
+++ b/docs/resources/port.md
@@ -5,11 +5,13 @@ description: |-
   Manipulate device ports
 ---
 
-# metal_port
+# metal_port (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_port`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_port) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_port`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to set up network ports on an Equnix Metal device. This resource can control both physical and bond ports.
 
-This Terraform resource doesn't create an API resource in Equinix Metal, but rather provides finer control for (Layer 2 networking)[https://metal.equinix.com/developers/docs/layer2-networking/].
+This Terraform resource doesn't create an API resource in Equinix Metal, but rather provides finer control for [`Layer 2 networking`](https://metal.equinix.com/developers/docs/layer2-networking/).
 
 The port resource referred is created together with device and accessible either via the device resource or over `/port/<uuid>` API path.
 

--- a/docs/resources/port_vlan_attachment.md
+++ b/docs/resources/port_vlan_attachment.md
@@ -5,7 +5,9 @@ description: |-
   Provides a Resource for Attaching VLANs to Device Ports
 ---
 
-# metal_port_vlan_attachment
+# metal_port_vlan_attachment (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_port_vlan_attachment`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_port_vlan_attachment) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_port_vlan_attachment`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to attach device ports to VLANs.
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Project resource.
 ---
 
-# metal\_project
+# metal_project (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_project`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_project) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_project`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal project resource to allow you manage devices
 in your projects.

--- a/docs/resources/project_api_key.md
+++ b/docs/resources/project_api_key.md
@@ -3,15 +3,15 @@ page_title: "Equinix Metal: Metal Project API Key"
 subcategory: ""
 description: |-
   Create Equinix Metal Project API Keys
-  ---
+---
 
-# metal_project_api_key
+# metal_project_api_key (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_project_api_key`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_project_api_key) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_project_api_key`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to create Metal Project API Key resources in Equinix Metal. Project API keys can be used to create and read resources in a single project. Each API key contains a token which can be used for authentication in Equinix Metal HTTP API (in HTTP request header `X-Auth-Token`).
 
-
 Read-only keys only allow to list and view existing resources, read-write keys can also be used to create resources.
-
 
 ## Example Usage
 

--- a/docs/resources/project_ssh_key.md
+++ b/docs/resources/project_ssh_key.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Project SSH key resource.
 ---
 
-# metal_project_ssh_key
+# metal_project_ssh_key (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_project_ssh_key`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_project_ssh_key) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_project_ssh_key`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal project SSH key resource to manage project-specific SSH keys.
 Project SSH keys will only be populated onto servers that belong to that project, in contrast to User SSH Keys.

--- a/docs/resources/reserved_ip_block.md
+++ b/docs/resources/reserved_ip_block.md
@@ -5,7 +5,9 @@ description: |-
   Provides a Resource for reserving IP addresses in the Equinix Metal Host
 ---
 
-# metal\_reserved\_ip\_block
+# metal_reserved_ip_block (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_reserved_ip_block`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_reserved_ip_block) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_reserved_ip_block`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to create and manage blocks of reserved IP addresses in a project.
 

--- a/docs/resources/spot_market_request.md
+++ b/docs/resources/spot_market_request.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal Spot Market Request Resource.
 ---
 
-# metal\_spot\_market\_request
+# metal_spot_market_request (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_spot_market_request`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_spot_market_request) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_spot_market_request`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides an Equinix Metal Spot Market Request resource to allow you to
 manage spot market requests on your account. For more detail on Spot Market, see [this article in Equinix Metal documentation](https://metal.equinix.com/developers/docs/deploy/spot-market/).

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -5,7 +5,9 @@ description: |-
   Provides an Equinix Metal SSH key resource.
 ---
 
-# metal\_ssh_key
+# metal_ssh_key (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_ssh_key`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_ssh_key) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_ssh_key`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to manage User SSH keys on your Equinix Metal user account. If you create a new device in a project, all the keys of the project's collaborators will be injected to the device.
 

--- a/docs/resources/user_api_key.md
+++ b/docs/resources/user_api_key.md
@@ -3,9 +3,11 @@ page_title: "Equinix Metal: Metal User API Key"
 subcategory: ""
 description: |-
   Create Equinix Metal User API Keys
-  ---
+---
 
-# metal_user_api_key
+# metal_user_api_key (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_user_api_key`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_user_api_key) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_user_api_key`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to create Metal User API Key resources in Equinix Metal. Each API key contains a token which can be used for authentication in Equinix Metal HTTP API (in HTTP request header `X-Auth-Token`).
 

--- a/docs/resources/virtual_circuit.md
+++ b/docs/resources/virtual_circuit.md
@@ -5,7 +5,9 @@ description: |-
   Create Equinix Fabric Virtual Circuit
 ---
 
-# metal_virtual_circuit
+# metal_virtual_circuit (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_virtual_circuit`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_virtual_circuit) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_virtual_circuit`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Use this resource to associate VLAN with a Dedicated Port from [Equinix Fabric - software-defined interconnections](https://metal.equinix.com/developers/docs/networking/fabric/#associating-a-vlan-with-a-dedicated-port).
 

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -5,7 +5,9 @@ description: |-
   Provides a resource for Equinix Metal Virtual Network.
 ---
 
-# metal_vlan
+# metal_vlan (Resource)
+
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_vlan`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_vlan) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_vlan`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
 Provides a resource to allow users to manage Virtual Networks in their projects.
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -5,5 +5,6 @@ description: |-
   (Removed) Provides an Equinix Metal Block Storage Volume Resource.
 ---
 
-Resource `metal_volume` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
+Resource `metal_volume` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.

--- a/docs/resources/volume_attachment.md
+++ b/docs/resources/volume_attachment.md
@@ -5,5 +5,6 @@ description: |-
   (Removed) Provides attachment of volumes to devices in the Equinix Metal Host.
 ---
 
-Resource `metal_volume_attachment` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
 
+Resource `metal_volume_attachment` was removed in version 3.0.0, and the API support was deprecated on June 1st 2021. See https://metal.equinix.com/developers/docs/storage/elastic-block-storage/#elastic-block-storage for more details.

--- a/docs/resources/vrf.md
+++ b/docs/resources/vrf.md
@@ -7,6 +7,8 @@ description: |-
 
 # metal_vrf (Resource)
 
+!> **PROVIDER DEPRECATED:** Equinix Metal Provider is now Deprecated. Please consider using [`equinix_metal_vrf`](https://registry.terraform.io/providers/equinix/equinix/latest/docs/resources/equinix_metal_vrf) resource from the [Equinix provider](https://registry.terraform.io/providers/equinix/equinix/latest/docs) instead of `metal_vrf`. [See the Metal provider section for more details](../index.md#equinix-metal-provider) on the new provider and available migration guides.
+
 Use this resource to manage a VRF.
 
 ~> VRF features are not generally available. The interfaces related to VRF resources may change ahead of general availability.

--- a/metal/datasource_metal_connection.go
+++ b/metal/datasource_metal_connection.go
@@ -94,8 +94,8 @@ func dataSourceMetalConnection() *schema.Resource {
 		speeds = append(speeds, allowedSpeed.Str)
 	}
 	return &schema.Resource{
-		Read: dataSourceMetalConnectionRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalConnectionRead,
 		Schema: map[string]*schema.Schema{
 			"connection_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_device.go
+++ b/metal/datasource_metal_device.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceMetalDevice() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalDeviceRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalDeviceRead,
 		Schema: map[string]*schema.Schema{
 			"hostname": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_device_bgp_neighbors.go
+++ b/metal/datasource_metal_device_bgp_neighbors.go
@@ -85,7 +85,8 @@ func bgpRouteSchema() *schema.Resource {
 
 func dataSourceMetalDeviceBGPNeighbors() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalDeviceBGPNeighborsRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalDeviceBGPNeighborsRead,
 		Schema: map[string]*schema.Schema{
 			"device_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_facility.go
+++ b/metal/datasource_metal_facility.go
@@ -44,7 +44,8 @@ func capacitySchema() *schema.Schema {
 
 func dataSourceMetalFacility() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalFacilityRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalFacilityRead,
 		Schema: map[string]*schema.Schema{
 			"code": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_gateway.go
+++ b/metal/datasource_metal_gateway.go
@@ -8,8 +8,8 @@ import (
 
 func dataSourceMetalGateway() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalGatewayRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalGatewayRead,
 		Schema: map[string]*schema.Schema{
 			"gateway_id": {
 				Required:    true,

--- a/metal/datasource_metal_hardware_reservation.go
+++ b/metal/datasource_metal_hardware_reservation.go
@@ -9,8 +9,8 @@ import (
 
 func dataSourceMetalHardwareReservation() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalHardwareReservationRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalHardwareReservationRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_ip_block_ranges.go
+++ b/metal/datasource_metal_ip_block_ranges.go
@@ -9,8 +9,8 @@ import (
 
 func dataSourceMetalIPBlockRanges() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalIPBlockRangesRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalIPBlockRangesRead,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_metro.go
+++ b/metal/datasource_metal_metro.go
@@ -9,7 +9,8 @@ import (
 
 func dataSourceMetalMetro() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalMetroRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalMetroRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_operating_system.go
+++ b/metal/datasource_metal_operating_system.go
@@ -10,7 +10,8 @@ import (
 
 func dataSourceOperatingSystem() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalOperatingSystemRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalOperatingSystemRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_organization.go
+++ b/metal/datasource_metal_organization.go
@@ -10,8 +10,8 @@ import (
 
 func dataSourceMetalOrganization() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalOrganizationRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalOrganizationRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_port.go
+++ b/metal/datasource_metal_port.go
@@ -6,8 +6,8 @@ import (
 
 func dataSourceMetalPort() *schema.Resource {
 	return &schema.Resource{
-		Read: resourceMetalPortRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               resourceMetalPortRead,
 		Schema: map[string]*schema.Schema{
 			"port_id": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_precreated_ip_block.go
+++ b/metal/datasource_metal_precreated_ip_block.go
@@ -60,8 +60,9 @@ func dataSourceMetalPreCreatedIPBlock() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Read:   dataSourceMetalPreCreatedIPBlockRead,
-		Schema: s,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalPreCreatedIPBlockRead,
+		Schema:             s,
 	}
 }
 

--- a/metal/datasource_metal_project.go
+++ b/metal/datasource_metal_project.go
@@ -11,7 +11,8 @@ import (
 
 func dataSourceMetalProject() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalProjectRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalProjectRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_project_ssh_key.go
+++ b/metal/datasource_metal_project_ssh_key.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceMetalProjectSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalProjectSSHKeyRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalProjectSSHKeyRead,
 		Schema: map[string]*schema.Schema{
 			"search": {
 				Type:         schema.TypeString,

--- a/metal/datasource_metal_reserved_ip_block.go
+++ b/metal/datasource_metal_reserved_ip_block.go
@@ -11,7 +11,8 @@ import (
 
 func dataSourceMetalReservedIPBlock() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalReservedIPBlockRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalReservedIPBlockRead,
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_spot_market_price.go
+++ b/metal/datasource_metal_spot_market_price.go
@@ -9,7 +9,8 @@ import (
 
 func dataSourceSpotMarketPrice() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalSpotMarketPriceRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalSpotMarketPriceRead,
 		Schema: map[string]*schema.Schema{
 			"facility": {
 				Type:          schema.TypeString,

--- a/metal/datasource_metal_spot_market_request.go
+++ b/metal/datasource_metal_spot_market_request.go
@@ -10,8 +10,8 @@ import (
 
 func dataSourceMetalSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalSpotMarketRequestRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalSpotMarketRequestRead,
 		Schema: map[string]*schema.Schema{
 			"request_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_virtual_circuit.go
+++ b/metal/datasource_metal_virtual_circuit.go
@@ -7,8 +7,8 @@ import (
 
 func dataSourceMetalVirtualCircuit() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalVirtualCircuitRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalVirtualCircuitRead,
 		Schema: map[string]*schema.Schema{
 			"virtual_circuit_id": {
 				Type:        schema.TypeString,

--- a/metal/datasource_metal_vlan.go
+++ b/metal/datasource_metal_vlan.go
@@ -9,7 +9,8 @@ import (
 
 func dataSourceMetalVlan() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalVlanRead,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalVlanRead,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/datasource_metal_vrf.go
+++ b/metal/datasource_metal_vrf.go
@@ -6,8 +6,8 @@ import (
 
 func dataSourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceMetalVRFRead,
-
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               dataSourceMetalVRFRead,
 		Schema: map[string]*schema.Schema{
 			"vrf_id": {
 				Required:    true,

--- a/metal/internal/datalist/schema.go
+++ b/metal/internal/datalist/schema.go
@@ -77,6 +77,7 @@ func NewResource(config *ResourceConfig) *schema.Resource {
 	}
 
 	return &schema.Resource{
+		DeprecationMessage: "Equinix Metal Provider is now Deprecated (End-of-Life scheduled for July 1, 2023) meaning that this software is only supported or maintained by Equinix Metal and its community in a case-by-case basis. The Equinix provider (https://registry.terraform.io/providers/equinix/equinix/latest/docs) has full support for existing Terraform managed Metal resources once Terraform configuration and state are adapted. The Equinix provider manages resources including Network Edge and Fabric in addition to Metal. Please review the Metal to Equinix provider migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_equinix_metal",
 		ReadContext: dataListResourceRead(config),
 		Schema:      datasourceSchema,
 	}

--- a/metal/provider.go
+++ b/metal/provider.go
@@ -8,6 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const deprecatedProviderMsg = "Equinix Metal Provider is now Deprecated (End-of-Life scheduled for July 1, 2023) meaning that this software is only supported or maintained by Equinix Metal and its community in a case-by-case basis. The Equinix provider (https://registry.terraform.io/providers/equinix/equinix/latest/docs) has full support for existing Terraform managed Metal resources once Terraform configuration and state are adapted. The Equinix provider manages resources including Network Edge and Fabric in addition to Metal. Please review the Metal to Equinix provider migration guide: https://registry.terraform.io/providers/equinix/equinix/latest/docs/guides/migration_guide_equinix_metal"
+
 var (
 	metalMutexKV         = NewMutexKV()
 	DeviceNetworkTypes   = []string{"layer3", "hybrid", "layer2-individual", "layer2-bonded"}

--- a/metal/resource_metal_bgp_session.go
+++ b/metal/resource_metal_bgp_session.go
@@ -10,9 +10,10 @@ import (
 
 func resourceMetalBGPSession() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalBGPSessionCreate,
-		Read:   resourceMetalBGPSessionRead,
-		Delete: resourceMetalBGPSessionDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalBGPSessionCreate,
+		Read:               resourceMetalBGPSessionRead,
+		Delete:             resourceMetalBGPSessionDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_connection.go
+++ b/metal/resource_metal_connection.go
@@ -53,10 +53,11 @@ func resourceMetalConnection() *schema.Resource {
 		speeds = append(speeds, allowedSpeed.Str)
 	}
 	return &schema.Resource{
-		Read:   resourceMetalConnectionRead,
-		Create: resourceMetalConnectionCreate,
-		Delete: resourceMetalConnectionDelete,
-		Update: resourceMetalConnectionUpdate,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               resourceMetalConnectionRead,
+		Create:             resourceMetalConnectionCreate,
+		Delete:             resourceMetalConnectionDelete,
+		Update:             resourceMetalConnectionUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_device.go
+++ b/metal/resource_metal_device.go
@@ -32,6 +32,7 @@ var (
 
 func resourceMetalDevice() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: deprecatedProviderMsg,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),

--- a/metal/resource_metal_device_network_type.go
+++ b/metal/resource_metal_device_network_type.go
@@ -10,10 +10,11 @@ import (
 
 func resourceMetalDeviceNetworkType() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalDeviceNetworkTypeCreate,
-		Read:   resourceMetalDeviceNetworkTypeRead,
-		Delete: resourceMetalDeviceNetworkTypeDelete,
-		Update: resourceMetalDeviceNetworkTypeUpdate,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalDeviceNetworkTypeCreate,
+		Read:               resourceMetalDeviceNetworkTypeRead,
+		Delete:             resourceMetalDeviceNetworkTypeDelete,
+		Update:             resourceMetalDeviceNetworkTypeUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_gateway.go
+++ b/metal/resource_metal_gateway.go
@@ -31,9 +31,10 @@ func intInSlice(valid []int) schema.SchemaValidateFunc {
 func resourceMetalGateway() *schema.Resource {
 
 	return &schema.Resource{
-		Read:   resourceMetalGatewayRead,
-		Create: resourceMetalGatewayCreate,
-		Delete: resourceMetalGatewayDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               resourceMetalGatewayRead,
+		Create:             resourceMetalGatewayCreate,
+		Delete:             resourceMetalGatewayDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_ip_attachment.go
+++ b/metal/resource_metal_ip_attachment.go
@@ -22,9 +22,10 @@ func resourceMetalIPAttachment() *schema.Resource {
 		Required: true,
 	}
 	return &schema.Resource{
-		Create: resourceMetalIPAttachmentCreate,
-		Read:   resourceMetalIPAttachmentRead,
-		Delete: resourceMetalIPAttachmentDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalIPAttachmentCreate,
+		Read:               resourceMetalIPAttachmentRead,
+		Delete:             resourceMetalIPAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_organization.go
+++ b/metal/resource_metal_organization.go
@@ -1,18 +1,20 @@
 package metal
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/packethost/packngo"
-	"regexp"
 )
 
 func resourceMetalOrganization() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalOrganizationCreate,
-		Read:   resourceMetalOrganizationRead,
-		Update: resourceMetalOrganizationUpdate,
-		Delete: resourceMetalOrganizationDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalOrganizationCreate,
+		Read:               resourceMetalOrganizationRead,
+		Update:             resourceMetalOrganizationUpdate,
+		Delete:             resourceMetalOrganizationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_port.go
+++ b/metal/resource_metal_port.go
@@ -21,6 +21,7 @@ var (
 
 func resourceMetalPort() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: deprecatedProviderMsg,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),

--- a/metal/resource_metal_port_vlan_attachment.go
+++ b/metal/resource_metal_port_vlan_attachment.go
@@ -10,14 +10,14 @@ import (
 
 func resourceMetalPortVlanAttachment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalPortVlanAttachmentCreate,
-		Read:   resourceMetalPortVlanAttachmentRead,
-		Delete: resourceMetalPortVlanAttachmentDelete,
-		Update: resourceMetalPortVlanAttachmentUpdate,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalPortVlanAttachmentCreate,
+		Read:               resourceMetalPortVlanAttachmentRead,
+		Delete:             resourceMetalPortVlanAttachmentDelete,
+		Update:             resourceMetalPortVlanAttachmentUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-
 		Schema: map[string]*schema.Schema{
 			"force_bond": {
 				Type:        schema.TypeBool,

--- a/metal/resource_metal_project.go
+++ b/metal/resource_metal_project.go
@@ -15,10 +15,11 @@ var uuidRE = regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-
 
 func resourceMetalProject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalProjectCreate,
-		Read:   resourceMetalProjectRead,
-		Update: resourceMetalProjectUpdate,
-		Delete: resourceMetalProjectDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalProjectCreate,
+		Read:               resourceMetalProjectRead,
+		Update:             resourceMetalProjectUpdate,
+		Delete:             resourceMetalProjectDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_project_api_key.go
+++ b/metal/resource_metal_project_api_key.go
@@ -39,10 +39,11 @@ func resourceMetalProjectAPIKey() *schema.Resource {
 		Description: "UUID of project which the new API key is scoped to",
 	}
 	return &schema.Resource{
-		Create: resourceMetalAPIKeyCreate,
-		Read:   resourceMetalAPIKeyRead,
-		Delete: resourceMetalAPIKeyDelete,
-		Schema: projectKeySchema,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalAPIKeyCreate,
+		Read:               resourceMetalAPIKeyRead,
+		Delete:             resourceMetalAPIKeyDelete,
+		Schema:             projectKeySchema,
 	}
 }
 

--- a/metal/resource_metal_project_ssh_key.go
+++ b/metal/resource_metal_project_ssh_key.go
@@ -13,10 +13,11 @@ func resourceMetalProjectSSHKey() *schema.Resource {
 		Required:    true,
 	}
 	return &schema.Resource{
-		Create: resourceMetalSSHKeyCreate,
-		Read:   resourceMetalSSHKeyRead,
-		Update: resourceMetalSSHKeyUpdate,
-		Delete: resourceMetalSSHKeyDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalSSHKeyCreate,
+		Read:               resourceMetalSSHKeyRead,
+		Update:             resourceMetalSSHKeyUpdate,
+		Delete:             resourceMetalSSHKeyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_reserved_ip_block.go
+++ b/metal/resource_metal_reserved_ip_block.go
@@ -216,10 +216,11 @@ func resourceMetalReservedIPBlock() *schema.Resource {
 	// TODO: add comments field, used for reservations that are not automatically approved
 
 	return &schema.Resource{
-		Create: resourceMetalReservedIPBlockCreate,
-		Read:   resourceMetalReservedIPBlockRead,
-		Update: resourceMetalReservedIPBlockUpdate,
-		Delete: resourceMetalReservedIPBlockDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalReservedIPBlockCreate,
+		Read:               resourceMetalReservedIPBlockRead,
+		Update:             resourceMetalReservedIPBlockUpdate,
+		Delete:             resourceMetalReservedIPBlockDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_spot_market_request.go
+++ b/metal/resource_metal_spot_market_request.go
@@ -13,9 +13,10 @@ import (
 
 func resourceMetalSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalSpotMarketRequestCreate,
-		Read:   resourceMetalSpotMarketRequestRead,
-		Delete: resourceMetalSpotMarketRequestDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalSpotMarketRequestCreate,
+		Read:               resourceMetalSpotMarketRequestRead,
+		Delete:             resourceMetalSpotMarketRequestDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_ssh_key.go
+++ b/metal/resource_metal_ssh_key.go
@@ -51,10 +51,11 @@ func metalSSHKeyCommonFields() map[string]*schema.Schema {
 
 func resourceMetalSSHKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalSSHKeyCreate,
-		Read:   resourceMetalSSHKeyRead,
-		Update: resourceMetalSSHKeyUpdate,
-		Delete: resourceMetalSSHKeyDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalSSHKeyCreate,
+		Read:               resourceMetalSSHKeyRead,
+		Update:             resourceMetalSSHKeyUpdate,
+		Delete:             resourceMetalSSHKeyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_user_api_key.go
+++ b/metal/resource_metal_user_api_key.go
@@ -12,9 +12,10 @@ func resourceMetalUserAPIKey() *schema.Resource {
 		Description: "UUID of user owning this key",
 	}
 	return &schema.Resource{
-		Create: resourceMetalAPIKeyCreate,
-		Read:   resourceMetalAPIKeyRead,
-		Delete: resourceMetalAPIKeyDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalAPIKeyCreate,
+		Read:               resourceMetalAPIKeyRead,
+		Delete:             resourceMetalAPIKeyDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_virtual_circuit.go
+++ b/metal/resource_metal_virtual_circuit.go
@@ -15,10 +15,11 @@ import (
 
 func resourceMetalVirtualCircuit() *schema.Resource {
 	return &schema.Resource{
-		Read:   resourceMetalVirtualCircuitRead,
-		Create: resourceMetalVirtualCircuitCreate,
-		Update: resourceMetalVirtualCircuitUpdate,
-		Delete: resourceMetalVirtualCircuitDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Read:               resourceMetalVirtualCircuitRead,
+		Create:             resourceMetalVirtualCircuitCreate,
+		Update:             resourceMetalVirtualCircuitUpdate,
+		Delete:             resourceMetalVirtualCircuitDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -223,8 +224,8 @@ func resourceMetalVirtualCircuitRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	return setMap(d, map[string]interface{}{
-		"project_id":    vc.Project.ID,
-		"port_id":       portID,
+		"project_id": vc.Project.ID,
+		"port_id":    portID,
 		"vlan_id": func(d *schema.ResourceData, k string) error {
 			if vc.VirtualNetwork != nil {
 				return d.Set(k, vc.VirtualNetwork.ID)

--- a/metal/resource_metal_vlan.go
+++ b/metal/resource_metal_vlan.go
@@ -10,9 +10,10 @@ import (
 
 func resourceMetalVlan() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceMetalVlanCreate,
-		Read:   resourceMetalVlanRead,
-		Delete: resourceMetalVlanDelete,
+		DeprecationMessage: deprecatedProviderMsg,
+		Create:             resourceMetalVlanCreate,
+		Read:               resourceMetalVlanRead,
+		Delete:             resourceMetalVlanDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/metal/resource_metal_vrf.go
+++ b/metal/resource_metal_vrf.go
@@ -10,6 +10,7 @@ import (
 
 func resourceMetalVRF() *schema.Resource {
 	return &schema.Resource{
+		DeprecationMessage: deprecatedProviderMsg,
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),


### PR DESCRIPTION
Part of https://github.com/equinix/terraform-provider-metal/issues/232

 Terraform Re

- [x] Registry should be updated with a deprecation notice ([index.md](https://github.com/equinix/terraform-provider-metal/blob/main/docs/index.md))
- [x] Terraform resource documentation should be updated with a deprecation notice in support of the new resources
- [x] Terraform provider should include any deprecation messages available through metadata or warning messages (https://www.terraform.io/plugin/sdkv2/best-practices/deprecations#example-resource-renaming is this available in v1 sdk?)